### PR TITLE
Thermostat: PR 3 - fix: change env files configs - gitattr, prettier, eslint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,13 @@
-# This line resolve warning
+# This configuration resolves Git warnings related to line endings:
 #   This diff contains a change in line endings from 'LF' to 'CRLF'.
 #
-# link: https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings
+# After creating the config, the above error is hidden but may show
+# this one for some files:
+#   This diff contains a change in line endings from 'CRLF' to 'LF'.
+#
+# Refer to the following link for more information about this
+# configuration file:
+#   https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings
 
-# Use LF for all files because this project used on linux driven controller
+# Use LF for all files as this project runs on a Linux-driven controller
 * text=auto eol=lf

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,5 +4,6 @@
   "tabWidth": 2,
   "semi": true,
   "useTabs": false,
-  "singleQuote": true
+  "singleQuote": true,
+  "quoteProps": "preserve"
 }

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -28,6 +28,7 @@ module.exports = [
       "object-shorthand": "off",
       "class-methods-use-this": "off",
       indent: ["error", 2],
+      "quote-props": ["error", "preserve"]
     },
     plugins: {
       prettier: prettierPlugin,


### PR DESCRIPTION
Пофиксил с помошью настроек в файлах конфигурации два не приятных поведения
1) С помошью gitattr изменил дефолтное поведение на windows чтобы git не менял окончания в файлах при закачке из репозитория с LF на CRLF каждый раз - это вызывает предупреждения каждый раз при обратных коммитах в репо
2) С помошью конфига линтера и бьютефаера - пофиксил их желание убирать везде где можно одинарные кавычки в названиях ключей JS - это нужно для того чтобы ключи являющиеся не латинскими символами в транслитераторе были заключены в скобки