### PR TITLE
Thermostat: PR 5 - feat: add init script and empty module with init()

### DIFF
--- a/scenarios/thermostat/scenario-init-thermostat.js
+++ b/scenarios/thermostat/scenario-init-thermostat.js
@@ -1,0 +1,110 @@
+/**
+ * @file scenario-init-thermostat.js
+ * @description Script for init scenarios of the SCENARIO_TYPE_STR type
+ *     This script:
+ *     - Loads all scenario configurations of the specific type from a file
+ *     - Finds all active scenarios of this type
+ *     - Initializes them according to the settings specified in each scenario
+ *
+ * @author Vitalii Gaponov <vitalii.gaponov@wirenboard.com>
+ * @link JSDoc comments format <https://jsdoc.app/> - Google styleguide
+ */
+
+/**
+ * Required version of the common scenario configuration file structure
+ *   The version changes rarely, only when there are modifications
+ *   to the schema at the same level as the scenarios[] array
+ * @type {number}
+ */
+var REQUIRED_GENERAL_CFG_VER = 1;
+
+/**
+ * Required version of the configuration for this type of scenarios
+ *   The version changes every time the structure of the configuration
+ *   for this scenario type is modified
+ * @type {number}
+ */
+var REQUIRED_SCENARIO_CFG_VER = 1;
+
+/**
+ * String of the absolute path to the scenario configuration file
+ * @type {string}
+ */
+var CONFIG_PATH = '/etc/wb-scenarios.conf';
+
+/**
+ * Scenario type for searching in the array of all scenario configurations
+ * @type {string}
+ */
+var SCENARIO_TYPE_STR = 'thermostat';
+
+var helpers = require('scenarios-general-helpers.mod');
+var scenarioModule = require('thermostat.mod');
+
+/**
+ * Initializes a scenario using the specified settings
+ * @param {object} scenario - The scenario object containing the settings
+ * @returns {void}
+ */
+function initializeScenario(scenario) {
+  log.debug('Processing scenario: ' + JSON.stringify(scenario));
+
+  var cfg = {
+    idPrefix: scenario.idPrefix,
+    targetTemp: scenario.targetTemperature,
+    tempLimitsMin: scenario.temperatureLimits.min,
+    tempLimitsMax: scenario.temperatureLimits.max,
+    hysteresis: scenario.hysteresis,
+    tempSensor: scenario.temperatureSensor,
+    actuator: scenario.actuator,
+  };
+  var isInitSuccess = scenarioModule.init(scenario.name, cfg);
+
+  if (isInitSuccess !== true) {
+    log.error(
+      'Error: Init operation aborted for ' +
+        'scenario name: "' +
+        scenario.name +
+        '" ' +
+        'with idPrefix: "' +
+        scenario.idPrefix +
+        '"'
+    );
+    return;
+  }
+
+  log.debug('Initialization successful for: ' + scenario.name);
+}
+
+function main() {
+  log.debug('Start initialisation ' + SCENARIO_TYPE_STR + ' scenario');
+  var listAllScenarios = helpers.readAndValidateScenariosConfig(
+    CONFIG_PATH,
+    REQUIRED_GENERAL_CFG_VER
+  );
+  if (!listAllScenarios) return;
+
+  var matchedScenarios = helpers.findAllActiveScenariosWithType(
+    listAllScenarios,
+    SCENARIO_TYPE_STR,
+    REQUIRED_SCENARIO_CFG_VER
+  );
+  if (matchedScenarios.length === 0) {
+    log.debug(
+      'No correct and active scenarios of type "' +
+        SCENARIO_TYPE_STR +
+        '" found'
+    );
+    return;
+  }
+
+  log.debug('Number of matched scenarios: ' + matchedScenarios.length);
+  log.debug('Matched scenarios JSON: ' + JSON.stringify(matchedScenarios));
+
+  for (var i = 0; i < matchedScenarios.length; i++) {
+    initializeScenario(matchedScenarios[i]);
+  }
+}
+
+// This delay need for correct init all devices after creation
+setTimeout(main, 1000);

--- a/scenarios/thermostat/scenario-init-thermostat.js
+++ b/scenarios/thermostat/scenario-init-thermostat.js
@@ -106,5 +106,4 @@ function main() {
   }
 }
 
-// This delay need for correct init all devices after creation
-setTimeout(main, 1000);
+main();

--- a/scenarios/thermostat/thermostat.mod.js
+++ b/scenarios/thermostat/thermostat.mod.js
@@ -1,0 +1,45 @@
+/**
+ * @file thermostat.mod.js
+ * @description Module for initializing the thermostat algorithm
+ *     based on user-specified parameters
+ *
+ * @author Vitalii Gaponov <vitalii.gaponov@wirenboard.com>
+ * @link JSDoc comments format <https://jsdoc.app/> - Google styleguide
+ */
+
+/**
+ * @typedef {Object} ThermostatConfig
+ * @property {string} [idPrefix] Optional prefix for the name to identify
+ *     the virtual device and rule:
+ *     - If specified, the virtual device and rule will be named
+ *       `wbsc_<!idPrefix!>` and `wbru_<!idPrefix!>`
+ *     - If not specified (undefined), the name will be generated
+ *       by transliterating the name passed to `init()`
+ * @property {number} targetTemp Target temperature set by the user
+ * @property {number} hysteresis Hysteresis value (switching range)
+ * @property {number} tempLimitsMin Lower limit for temperature setting
+ * @property {number} tempLimitsMax Upper limit for temperature setting
+ * @property {string} tempSensor Name of the input control topic - monitored
+ *     Example: temperature sensor whose value should be tracked
+ *     'temp_sensor/temp_value'
+ * @property {string} actuator Name of the output control topic - controlled
+ *     Example: relay output to be controlled - 'relay_module/K2'
+ */
+
+/**
+ * Initializes a virtual device and defines a rule
+ * for controlling the device
+ * @param {string} deviceTitle Name of the virtual device
+ * @param {ThermostatConfig} cfg Configuration parameters
+ * @returns {boolean} Returns true if initialization is successful, otherwise false
+ */
+function init(deviceTitle, cfg) {
+  /** TODO: Add validation logic + thermostat logic*/
+
+  return true;
+}
+
+exports.init = function (deviceTitle, cfg) {
+  var res = init(deviceTitle, cfg);
+  return res;
+};


### PR DESCRIPTION
Добавлены
1) скрипт инициализации сценариев с типом термостат
Он выполняет две основные задачи
- Открыть конфиг, проверить версию читаемого конфига и версию инстанса сценария на требуемые в коде
- Запустить инициализацию всех корректных активированных галочкой в конфигураторе сценариев с типом термостат

2) Базовый вариант базовый модуль термостата содержащий метод init вызываемый для каждого найденного инстанса сценария
Модуль имеет только определение функции init() и комментарии определяющие структуру объекта cfg для данного типа сценария