### PR TITLE
Thermostat: PR 9 - feat: add actuator and sensor topics error base processing

### DIFF
--- a/scenarios/thermostat/thermostat.mod.js
+++ b/scenarios/thermostat/thermostat.mod.js
@@ -139,7 +139,10 @@ function createBasicVd(vdName, vdTitle, managedRulesId) {
     log.error('Virtual device "{}" already exists in system', vdName);
     return null;
   }
-  log.debug('Virtual device "{}" not exists in system -> create new', vdName);
+  log.debug(
+    'Virtual device "{}" not exists in system -> create new',
+    vdName
+  );
 
   var vdCfg = {
     title: vdTitle,
@@ -401,14 +404,18 @@ function createRules(cfg, genNames, vdObj, managedRulesId) {
     then: function (newValue, devName, cellName) {
       var sensorErrValue = dev[sensorErrorTopic];
       if (sensorErrValue !== metaNotDefined && sensorErrValue !== '') {
-        log.error('Temperature sensor error topic {} state: {}', sensorErrorTopic, sensorErrValue);
+        log.error(
+          'Temperature sensor error topic {} state: {}',
+          sensorErrorTopic,
+          sensorErrValue
+        );
         ctrlCurTemp.setError(sensorErrValue);
         ctrlEnable.setValue(false);
       } else {
         // The error is cleared – reset the control's error state
         ctrlCurTemp.setError('');
       }
-    }
+    },
   };
   var ruleId = defineRule(genNames.vDevice + '_sensor_error_watch', ruleCfg);
   // This rule not disable when user use switch in virtual device
@@ -423,16 +430,23 @@ function createRules(cfg, genNames, vdObj, managedRulesId) {
     then: function (newValue, devName, cellName) {
       var actuatorErrValue = dev[actuatorErrorTopic];
       if (actuatorErrValue !== metaNotDefined && actuatorErrValue !== '') {
-        log.error('Actuator (heater) error topic {} state: {}', actuatorErrorTopic, actuatorErrValue);
+        log.error(
+          'Actuator (heater) error topic {} state: {}',
+          actuatorErrorTopic,
+          actuatorErrValue
+        );
         ctrlActuator.setError(actuatorErrValue);
         ctrlEnable.setValue(false);
       } else {
         // The error is cleared – reset the control's error state
         ctrlActuator.setError('');
       }
-    }
+    },
   };
-  var ruleId = defineRule(genNames.vDevice + '_actuator_error_watch', ruleCfg);
+  var ruleId = defineRule(
+    genNames.vDevice + '_actuator_error_watch',
+    ruleCfg
+  );
   // This rule not disable when user use switch in virtual device
   log.debug('Actuator error handling rule created with ID="{}"', ruleId);
 }

--- a/scenarios/thermostat/thermostat.mod.js
+++ b/scenarios/thermostat/thermostat.mod.js
@@ -389,48 +389,52 @@ function createRules(cfg, genNames, vdObj, managedRulesId) {
   managedRulesId.push(ruleId);
   log.debug('Target temp change rule created success with ID "{}"', ruleId);
 
-  // FIXME: This is will be fixed in feature - must be 'null'
+  // FIXME: This is will be fixed in feature time - must be 'null'
   var metaNotDefined = undefined;
 
+  /**
+   * Rule to handle temperature sensor errors
+   */
   var sensorErrorTopic = cfg.tempSensor + '#error';
-  debug('sensorErrorTopic='+sensorErrorTopic)
-  var actuatorErrorTopic = cfg.actuator + '#error';
-  debug('actuatorErrorTopic='+actuatorErrorTopic)
-  ruleCfg = {
-    whenChanged: [sensorErrorTopic, actuatorErrorTopic],
+  var ruleCfg = {
+    whenChanged: [sensorErrorTopic],
     then: function (newValue, devName, cellName) {
       var sensorErrValue = dev[sensorErrorTopic];
       if (sensorErrValue !== metaNotDefined && sensorErrValue !== '') {
-        if (ctrlCurTemp !== null) {
-          log.error('Temperature sensor error topic {} state: {}', sensorErrorTopic, sensorErrValue);
-          ctrlCurTemp.setError(sensorErrValue);
-          ctrlEnable.setValue(false);
-        }
+        log.error('Temperature sensor error topic {} state: {}', sensorErrorTopic, sensorErrValue);
+        ctrlCurTemp.setError(sensorErrValue);
+        ctrlEnable.setValue(false);
       } else {
         // The error is cleared – reset the control's error state
-        if (ctrlCurTemp !== null) {
-          ctrlCurTemp.setError('');
-        }
-      }
-
-      var actuatorErrValue = dev[actuatorErrorTopic];
-      if (actuatorErrValue !== metaNotDefined && actuatorErrValue !== '') {
-        if (ctrlActuator !== null) {
-          log.error('Actuator (heater) error topic {} state: {}', actuatorErrorTopic, actuatorErrValue);
-          ctrlActuator.setError(actuatorErrValue);
-          ctrlEnable.setValue(false);
-        }
-      } else {
-        // The error is cleared – reset the control's error state
-        if (ctrlActuator !== null) {
-          ctrlActuator.setError('');
-        }
+        ctrlCurTemp.setError('');
       }
     }
   };
-  var ruleId = defineRule(genNames.vDevice + '_meta_error_watch', ruleCfg)
+  var ruleId = defineRule(genNames.vDevice + '_sensor_error_watch', ruleCfg);
   // This rule not disable when user use switch in virtual device
-  log.debug('Meta error watch rule created with ID="{}"', ruleId);
+  log.debug('Temp. sensor error handling rule created with ID="{}"', ruleId);
+
+  /**
+   * Rule to handle actuator errors
+   */
+  var actuatorErrorTopic = cfg.actuator + '#error';
+  ruleCfg = {
+    whenChanged: [actuatorErrorTopic],
+    then: function (newValue, devName, cellName) {
+      var actuatorErrValue = dev[actuatorErrorTopic];
+      if (actuatorErrValue !== metaNotDefined && actuatorErrValue !== '') {
+        log.error('Actuator (heater) error topic {} state: {}', actuatorErrorTopic, actuatorErrValue);
+        ctrlActuator.setError(actuatorErrValue);
+        ctrlEnable.setValue(false);
+      } else {
+        // The error is cleared – reset the control's error state
+        ctrlActuator.setError('');
+      }
+    }
+  };
+  var ruleId = defineRule(genNames.vDevice + '_actuator_error_watch', ruleCfg);
+  // This rule not disable when user use switch in virtual device
+  log.debug('Actuator error handling rule created with ID="{}"', ruleId);
 }
 
 /**

--- a/scenarios/thermostat/thermostat.mod.js
+++ b/scenarios/thermostat/thermostat.mod.js
@@ -317,7 +317,10 @@ function tryClearReadonly(vdCtrlEnable, cfg) {
   var sensorErrVal = dev[cfg.tempSensor + '#error'];
   var actuatorErrVal = dev[cfg.actuator + '#error'];
 
-  if ((!sensorErrVal || sensorErrVal === '') && (!actuatorErrVal || actuatorErrVal === '')) {
+  if (
+    (!sensorErrVal || sensorErrVal === '') &&
+    (!actuatorErrVal || actuatorErrVal === '')
+  ) {
     vdCtrlEnable.setReadonly(false);
   }
 }
@@ -333,7 +336,13 @@ function tryClearReadonly(vdCtrlEnable, cfg) {
  * @param {ThermostatConfig} cfg Configuration parameters
  * @returns {number|null} The ID of the created rule, or `null` if failed
  */
-function createErrChangeRule(ruleName, sourceErrTopic, targetVdCtrl, vdCtrlEnable, cfg) {
+function createErrChangeRule(
+  ruleName,
+  sourceErrTopic,
+  targetVdCtrl,
+  vdCtrlEnable,
+  cfg
+) {
   var ruleCfg = {
     whenChanged: [sourceErrTopic],
     then: function (newValue, devName, cellName) {
@@ -454,12 +463,24 @@ function createRules(cfg, genNames, vdObj, managedRulesId) {
   log.debug('Target temp change rule created success with ID "{}"', ruleId);
 
   var sensorErrTopic = cfg.tempSensor + '#error';
-  ruleId = createErrChangeRule(genNames.ruleSensorErr, sensorErrTopic, vdCtrlCurTemp, vdCtrlEnable, cfg);
+  ruleId = createErrChangeRule(
+    genNames.ruleSensorErr,
+    sensorErrTopic,
+    vdCtrlCurTemp,
+    vdCtrlEnable,
+    cfg
+  );
   // This rule not disable when user use switch in virtual device
   log.debug('Temp. sensor error handling rule created with ID="{}"', ruleId);
 
   var actuatorErrTopic = cfg.actuator + '#error';
-  ruleId = createErrChangeRule(genNames.ruleActuatorErr, actuatorErrTopic, vdCtrlActuator, vdCtrlEnable, cfg);
+  ruleId = createErrChangeRule(
+    genNames.ruleActuatorErr,
+    actuatorErrTopic,
+    vdCtrlActuator,
+    vdCtrlEnable,
+    cfg
+  );
   // This rule not disable when user use switch in virtual device
   log.debug('Actuator error handling rule created with ID="{}"', ruleId);
 }

--- a/scenarios/thermostat/thermostat.mod.js
+++ b/scenarios/thermostat/thermostat.mod.js
@@ -347,16 +347,27 @@ function createErrChangeRule(
     whenChanged: [sourceErrTopic],
     then: function (newValue, devName, cellName) {
       if (newValue !== '') {
-        log.error(
-          'Scenario disabled: Get error for topic "{}". New error state: "{}"',
-          sourceErrTopic,
-          newValue
-        );
-        vdCtrlEnable.setReadonly(true);
-        vdCtrlEnable.setValue(false);
-        // FIXME: Set error must be after disable scenario rules
-        //        This seq important becoase we have bug about "err clearing"
         targetVdCtrl.setError(newValue);
+
+        var hasCriticalError =
+          newValue.indexOf('r') !== -1 || newValue.indexOf('w') !== -1;
+
+        if (hasCriticalError) {
+          log.error(
+            'Scenario disabled: Get critical error (r/w) for topic "{}". New error state: "{}"',
+            sourceErrTopic,
+            newValue
+          );
+          vdCtrlEnable.setReadonly(true);
+          vdCtrlEnable.setValue(false);
+        } else {
+          log.debug(
+            'Non-critical error (p) detected for topic "{}". New error state: "{}"',
+            sourceErrTopic,
+            newValue
+          );
+          // Non-critical error (p) - only display error state without disabling scenario
+        }
       } else {
         log.debug(
           'Error cleared for topic "{}". New error state: "{}"',

--- a/scenarios/thermostat/thermostat.mod.js
+++ b/scenarios/thermostat/thermostat.mod.js
@@ -39,6 +39,8 @@ function generateNames(idPrefix) {
     rule_temp_changed: baseRuleName + '_temp_changed',
     rule_set_sc_status: baseRuleName + '_set_sc_status',
     rule_set_target_t: baseRuleName + '_set_target_t',
+    rule_sensor_err: baseRuleName + '_sensor_error_changed',
+    rule_actuator_err: baseRuleName + '_actuator_error_changed',
   };
 
   return generatedNames;
@@ -440,7 +442,7 @@ function createRules(cfg, genNames, vdObj, managedRulesId) {
       }
     },
   };
-  var ruleId = defineRule(genNames.vDevice + '_sensor_error_watch', ruleCfg);
+  var ruleId = defineRule(genNames.rule_sensor_err, ruleCfg);
   // This rule not disable when user use switch in virtual device
   log.debug('Temp. sensor error handling rule created with ID="{}"', ruleId);
 
@@ -473,10 +475,7 @@ function createRules(cfg, genNames, vdObj, managedRulesId) {
       }
     },
   };
-  var ruleId = defineRule(
-    genNames.vDevice + '_actuator_error_watch',
-    ruleCfg
-  );
+  var ruleId = defineRule(genNames.rule_actuator_err, ruleCfg);
   // This rule not disable when user use switch in virtual device
   log.debug('Actuator error handling rule created with ID="{}"', ruleId);
 }

--- a/scenarios/thermostat/thermostat.mod.js
+++ b/scenarios/thermostat/thermostat.mod.js
@@ -318,8 +318,7 @@ function hasCriticalErr(errorVal) {
     return false;
   }
 
-  var containsCriticalError = errorVal.indexOf('r') !== -1 || errorVal.indexOf('w') !== -1;
-  return containsCriticalError;
+  return (errorVal.indexOf('r') !== -1 || errorVal.indexOf('w') !== -1);
 }
 
 /**
@@ -329,12 +328,8 @@ function hasCriticalErr(errorVal) {
  * @param {ThermostatConfig} cfg Configuration parameters
  */
 function tryClearReadonly(vdCtrlEnable, cfg) {
-  var sensorErrVal = dev[cfg.tempSensor + '#error'];
-  var actuatorErrVal = dev[cfg.actuator + '#error'];
-
-  if (
-    (sensorErrVal === undefined || hasCriticalErr(sensorErrVal) === false) &&
-    (actuatorErrVal === undefined || hasCriticalErr(actuatorErrVal) === false)
+  if ( !hasCriticalErr(dev[cfg.tempSensor + '#error']) &&
+       !hasCriticalErr(dev[cfg.actuator + '#error'])
   ) {
     vdCtrlEnable.setReadonly(false);
   }
@@ -366,7 +361,7 @@ function createErrChangeRule(
     then: function (newValue, devName, cellName) {
       targetVdCtrl.setError(newValue);
 
-      if (hasCriticalErr(newValue) === false) {
+      if (!hasCriticalErr(newValue)) {
         log.debug(
           'Error cleared or non-critical error (p) detected for topic "{}". New state: "{}"',
           sourceErrTopic,
@@ -402,7 +397,7 @@ function createErrChangeRule(
         // When timer stop - check still critical errors r/w
         var currentErrorVal = dev[sourceErrTopic];
 
-        if (hasCriticalErr(currentErrorVal) === true) {
+        if (hasCriticalErr(currentErrorVal)) {
           log.error(
             'Scenario disabled: critical error (r/w) for topic "{}" not cleared for {} ms. Current error state: "{}"',
             sourceErrTopic,

--- a/scenarios/thermostat/thermostat.mod.js
+++ b/scenarios/thermostat/thermostat.mod.js
@@ -130,10 +130,10 @@ function isConfigValid(cfg) {
  * Creates a basic virtual device with a rule switch if it not already exist
  * @param {string} vdName The name of the virtual device
  * @param {string} vdTitle The title of the virtual device
- * @param {Array<number>} rulesIdToToggle Array of rule IDs to toggle on switch
+ * @param {Array<number>} managedRulesId Array of rule IDs to toggle on switch
  * @returns {Object|null} The virtual device object if created, otherwise null
  */
-function createBasicVd(vdName, vdTitle, rulesIdToToggle) {
+function createBasicVd(vdName, vdTitle, managedRulesId) {
   var existingVdObj = getDevice(vdName);
   if (existingVdObj !== undefined) {
     log.error('Virtual device "{}" already exists in system', vdName);
@@ -162,11 +162,11 @@ function createBasicVd(vdName, vdTitle, rulesIdToToggle) {
   vdObj.addControl(vdCtrl.ruleEnabled, controlCfg);
 
   function toggleRules(newValue) {
-    for (var i = 0; i < rulesIdToToggle.length; i++) {
+    for (var i = 0; i < managedRulesId.length; i++) {
       if (newValue) {
-        enableRule(rulesIdToToggle[i]);
+        enableRule(managedRulesId[i]);
       } else {
-        disableRule(rulesIdToToggle[i]);
+        disableRule(managedRulesId[i]);
       }
     }
   }
@@ -307,9 +307,9 @@ function updateHeatingState(actuator, data) {
  * @param {ThermostatConfig} cfg Configuration parameters
  * @param {Object} genNames Generated names
  * @param {Object} vdObj Scenario virtual device
- * @param {Array<string>} rulesId Array of rule IDs for enabling/disabling
+ * @param {Array<string>} managedRulesId Array of rule IDs for enabling/disabling
  */
-function createRules(cfg, genNames, vdObj, rulesId) {
+function createRules(cfg, genNames, vdObj, managedRulesId) {
   var ruleCfg = {};
   var ruleId = null;
 
@@ -332,7 +332,7 @@ function createRules(cfg, genNames, vdObj, rulesId) {
     },
   };
   ruleId = defineRule(genNames.rule_temp_changed, ruleCfg);
-  rulesId.push(ruleId);
+  managedRulesId.push(ruleId);
   log.debug('Temperature changed rule created success with ID "{}"', ruleId);
 
   ruleCfg = {
@@ -342,7 +342,7 @@ function createRules(cfg, genNames, vdObj, rulesId) {
     },
   };
   ruleId = defineRule(genNames.rule_sync_act_status, ruleCfg);
-  rulesId.push(ruleId);
+  managedRulesId.push(ruleId);
   log.debug(
     'Sync actuator status rule created success with ID "{}"',
     ruleId
@@ -386,7 +386,7 @@ function createRules(cfg, genNames, vdObj, rulesId) {
     },
   };
   ruleId = defineRule(genNames.rule_set_target_t, ruleCfg);
-  rulesId.push(ruleId);
+  managedRulesId.push(ruleId);
   log.debug('Target temp change rule created success with ID "{}"', ruleId);
 
   // FIXME: This is will be fixed in feature - must be 'null'
@@ -446,8 +446,8 @@ function init(deviceTitle, cfg) {
   var genNames = generateNames(idPrefix);
 
   // Create a minimal basic virtual device to indicate errors if they occur
-  var rulesId = [];
-  var vdObj = createBasicVd(genNames.vDevice, deviceTitle, rulesId);
+  var managedRulesId = [];
+  var vdObj = createBasicVd(genNames.vDevice, deviceTitle, managedRulesId);
   if (vdObj === null) {
     return false;
   }
@@ -458,7 +458,7 @@ function init(deviceTitle, cfg) {
   }
 
   addCustomCellsToVd(vdObj, cfg);
-  createRules(cfg, genNames, vdObj, rulesId);
+  createRules(cfg, genNames, vdObj, managedRulesId);
 
   // Set first heater state after initialisation
   var data = {

--- a/scenarios/thermostat/thermostat.mod.js
+++ b/scenarios/thermostat/thermostat.mod.js
@@ -393,27 +393,29 @@ function createRules(cfg, genNames, vdObj, managedRulesId) {
   log.debug('Target temp change rule created success with ID "{}"', ruleId);
 
   // FIXME: This is will be fixed in feature time - must be 'null'
-  var metaNotDefined = undefined;
+  var metaUnset = undefined;
 
   /**
    * Rule to handle temperature sensor errors
    */
-  var sensorErrorTopic = cfg.tempSensor + '#error';
+  var sensorErrTopic = cfg.tempSensor + '#error';
   var ruleCfg = {
-    whenChanged: [sensorErrorTopic],
+    whenChanged: [sensorErrTopic],
     then: function (newValue, devName, cellName) {
-      var sensorErrValue = dev[sensorErrorTopic];
-      if (sensorErrValue !== metaNotDefined && sensorErrValue !== '') {
+      var sensorErrVal = dev[sensorErrTopic];
+      if (sensorErrVal !== metaUnset && sensorErrVal !== '') {
         log.error(
-          'Temperature sensor error topic {} state: {}',
-          sensorErrorTopic,
-          sensorErrValue
+          'Scenario disabled: Temperature sensor error topic {} state: {}',
+          sensorErrTopic,
+          sensorErrVal
         );
-        ctrlCurTemp.setError(sensorErrValue);
+        ctrlCurTemp.setError(sensorErrVal);
+        ctrlEnable.setReadonly(true);
         ctrlEnable.setValue(false);
       } else {
         // The error is cleared – reset the control's error state
         ctrlCurTemp.setError('');
+        ctrlEnable.setReadonly(false);
       }
     },
   };
@@ -424,22 +426,24 @@ function createRules(cfg, genNames, vdObj, managedRulesId) {
   /**
    * Rule to handle actuator errors
    */
-  var actuatorErrorTopic = cfg.actuator + '#error';
+  var actuatorErrTopic = cfg.actuator + '#error';
   ruleCfg = {
-    whenChanged: [actuatorErrorTopic],
+    whenChanged: [actuatorErrTopic],
     then: function (newValue, devName, cellName) {
-      var actuatorErrValue = dev[actuatorErrorTopic];
-      if (actuatorErrValue !== metaNotDefined && actuatorErrValue !== '') {
+      var actuatorErrVal = dev[actuatorErrTopic];
+      if (actuatorErrVal !== metaUnset && actuatorErrVal !== '') {
         log.error(
-          'Actuator (heater) error topic {} state: {}',
-          actuatorErrorTopic,
-          actuatorErrValue
+          'Scenario disabled: Actuator (heater) error topic {} state: {}',
+          actuatorErrTopic,
+          actuatorErrVal
         );
-        ctrlActuator.setError(actuatorErrValue);
+        ctrlActuator.setError(actuatorErrVal);
+        ctrlEnable.setReadonly(true);
         ctrlEnable.setValue(false);
       } else {
         // The error is cleared – reset the control's error state
         ctrlActuator.setError('');
+        ctrlEnable.setReadonly(false);
       }
     },
   };

--- a/scenarios/thermostat/thermostat.mod.js
+++ b/scenarios/thermostat/thermostat.mod.js
@@ -35,12 +35,12 @@ function generateNames(idPrefix) {
 
   var generatedNames = {
     vDevice: scenarioPrefix + idPrefix,
-    rule_sync_act_status: baseRuleName + '_sync_act_status',
-    rule_temp_changed: baseRuleName + '_temp_changed',
-    rule_set_sc_status: baseRuleName + '_set_sc_status',
-    rule_set_target_t: baseRuleName + '_set_target_t',
-    rule_sensor_err: baseRuleName + '_sensor_error_changed',
-    rule_actuator_err: baseRuleName + '_actuator_error_changed',
+    ruleSyncActStatus: baseRuleName + '_sync_act_status',
+    ruleTempChanged: baseRuleName + '_temp_changed',
+    ruleSetScStatus: baseRuleName + '_set_sc_status',
+    ruleSetTargetTemp: baseRuleName + '_set_target_t',
+    ruleSensorErr: baseRuleName + '_sensor_error_changed',
+    ruleActuatorErr: baseRuleName + '_actuator_error_changed',
   };
 
   return generatedNames;
@@ -353,7 +353,7 @@ function createRules(cfg, genNames, vdObj, managedRulesId) {
       updateHeatingState(cfg.actuator, data);
     },
   };
-  ruleId = defineRule(genNames.rule_temp_changed, ruleCfg);
+  ruleId = defineRule(genNames.ruleTempChanged, ruleCfg);
   managedRulesId.push(ruleId);
   log.debug('Temperature changed rule created success with ID "{}"', ruleId);
 
@@ -363,7 +363,7 @@ function createRules(cfg, genNames, vdObj, managedRulesId) {
       vdCtrlActuator.setValue(newValue);
     },
   };
-  ruleId = defineRule(genNames.rule_sync_act_status, ruleCfg);
+  ruleId = defineRule(genNames.ruleSyncActStatus, ruleCfg);
   managedRulesId.push(ruleId);
   log.debug(
     'Sync actuator status rule created success with ID "{}"',
@@ -389,7 +389,7 @@ function createRules(cfg, genNames, vdObj, managedRulesId) {
       }
     },
   };
-  ruleId = defineRule(genNames.rule_set_sc_status, ruleCfg);
+  ruleId = defineRule(genNames.ruleSetScStatus, ruleCfg);
   // This rule not disable when user use switch in virtual device
   log.debug(
     'Activate scenario status rule created success with ID "{}"',
@@ -408,7 +408,7 @@ function createRules(cfg, genNames, vdObj, managedRulesId) {
       updateHeatingState(cfg.actuator, data);
     },
   };
-  ruleId = defineRule(genNames.rule_set_target_t, ruleCfg);
+  ruleId = defineRule(genNames.ruleSetTargetTemp, ruleCfg);
   managedRulesId.push(ruleId);
   log.debug('Target temp change rule created success with ID "{}"', ruleId);
 
@@ -442,7 +442,7 @@ function createRules(cfg, genNames, vdObj, managedRulesId) {
       }
     },
   };
-  var ruleId = defineRule(genNames.rule_sensor_err, ruleCfg);
+  var ruleId = defineRule(genNames.ruleSensorErr, ruleCfg);
   // This rule not disable when user use switch in virtual device
   log.debug('Temp. sensor error handling rule created with ID="{}"', ruleId);
 
@@ -475,7 +475,7 @@ function createRules(cfg, genNames, vdObj, managedRulesId) {
       }
     },
   };
-  var ruleId = defineRule(genNames.rule_actuator_err, ruleCfg);
+  var ruleId = defineRule(genNames.ruleActuatorErr, ruleCfg);
   // This rule not disable when user use switch in virtual device
   log.debug('Actuator error handling rule created with ID="{}"', ruleId);
 }

--- a/scenarios/thermostat/thermostat.mod.js
+++ b/scenarios/thermostat/thermostat.mod.js
@@ -142,7 +142,7 @@ function createBasicVd(vdName, vdTitle, managedRulesId) {
     return null;
   }
   log.debug(
-    'Virtual device "{}" not exists in system -> create new',
+    'Virtual device "{}" does not exist in system -> create new VD',
     vdName
   );
 

--- a/scenarios/thermostat/thermostat.mod.js
+++ b/scenarios/thermostat/thermostat.mod.js
@@ -423,9 +423,11 @@ function createRules(cfg, genNames, vdObj, managedRulesId) {
           sensorErrTopic,
           newValue
         );
-        vdCtrlCurTemp.setError(newValue);
         vdCtrlEnable.setReadonly(true);
         vdCtrlEnable.setValue(false);
+        // FIXME: Set error must be after disable scenario rules
+        //        This seq important becoase we have bug about "err clearing"
+        vdCtrlCurTemp.setError(newValue);
       } else {
         log.debug(
           'Temperature sensor err cleared for topic {} state: {}',
@@ -455,9 +457,11 @@ function createRules(cfg, genNames, vdObj, managedRulesId) {
           actuatorErrTopic,
           newValue
         );
-        vdCtrlActuator.setError(newValue);
         vdCtrlEnable.setReadonly(true);
         vdCtrlEnable.setValue(false);
+        // FIXME: Set error must be after disable scenario rules
+        //        This seq important becoase we have bug about "err clearing"
+        vdCtrlActuator.setError(newValue);
       } else {
         log.debug(
           'Actuator (heater) err cleared for topic {} state: {}',

--- a/scenarios/thermostat/thermostat.mod.js
+++ b/scenarios/thermostat/thermostat.mod.js
@@ -392,9 +392,6 @@ function createRules(cfg, genNames, vdObj, managedRulesId) {
   managedRulesId.push(ruleId);
   log.debug('Target temp change rule created success with ID "{}"', ruleId);
 
-  // FIXME: This is will be fixed in feature time - must be 'null'
-  var metaUnset = undefined;
-
   /**
    * Rule to handle temperature sensor errors
    */
@@ -402,14 +399,13 @@ function createRules(cfg, genNames, vdObj, managedRulesId) {
   var ruleCfg = {
     whenChanged: [sensorErrTopic],
     then: function (newValue, devName, cellName) {
-      var sensorErrVal = dev[sensorErrTopic];
-      if (sensorErrVal !== metaUnset && sensorErrVal !== '') {
+      if (newValue !== '') {
         log.error(
           'Scenario disabled: Temperature sensor error topic {} state: {}',
           sensorErrTopic,
-          sensorErrVal
+          newValue
         );
-        ctrlCurTemp.setError(sensorErrVal);
+        ctrlCurTemp.setError(newValue);
         ctrlEnable.setReadonly(true);
         ctrlEnable.setValue(false);
       } else {
@@ -430,14 +426,13 @@ function createRules(cfg, genNames, vdObj, managedRulesId) {
   ruleCfg = {
     whenChanged: [actuatorErrTopic],
     then: function (newValue, devName, cellName) {
-      var actuatorErrVal = dev[actuatorErrTopic];
-      if (actuatorErrVal !== metaUnset && actuatorErrVal !== '') {
+      if (newValue !== '') {
         log.error(
           'Scenario disabled: Actuator (heater) error topic {} state: {}',
           actuatorErrTopic,
-          actuatorErrVal
+          newValue
         );
-        ctrlActuator.setError(actuatorErrVal);
+        ctrlActuator.setError(newValue);
         ctrlEnable.setReadonly(true);
         ctrlEnable.setValue(false);
       } else {


### PR DESCRIPTION
В данном PR добавлена функция createErrChangeRule() с помошью которой
- производится обработка ошибок топиков сенсора и актуатора путем выключения сценария при получении критичных ошибок - это ошибки "w" или "r" (ошибка "p" игнорируется)
- выключение происходит не сразу а через 10 секунд если критичная ошибка находится еще на месте и не была убрана драйвером

Если при работе сценария происходит ошибка чтения, записи или периода  на исходных топиках сенсора или нагревателя, то порядок действий такой:
1) При появлении ошибки топика актуатора или сенсора сценарий выключается
2) Далее ошибка копируется в топик соответствующего контрола виртуального девайса
3) При выключении сценария выключается нагреватель
4) Кнопка включения сценария блокируется, чтобы не разрешить пользователю включить сценарий пока он не пофиксит ошибки
![image](https://github.com/user-attachments/assets/8dc68694-7c89-4634-904d-da4d2a102d2a)

5) Когда ошибки на обоих топиках (актуатор и сенсор) удаляются - разблокируется возможность включения актуатора
6) При разблокированном переключателе - пользователь вручную включает сценарий (автоматического включения сценария после ошибки нет)

**Более корректные обработки ошибок топика температуры будут в следующем PR**