### PR TITLE
Thermostat: PR 12 - feat: add pre init wait linked topics + VD status control

### DIFF
--- a/scenarios/thermostat/thermostat.mod.js
+++ b/scenarios/thermostat/thermostat.mod.js
@@ -10,6 +10,7 @@
 var helpers = require('scenarios-general-helpers.mod');
 var Logger = require('logger.mod').Logger;
 var createBasicVd = require('virtual-device-helpers.mod').createBasicVd;
+var setVdTotalError = require('virtual-device-helpers.mod').setVdTotalError;
 
 var loggerFileLabel = 'WBSC-thermostat-mod';
 var log = new Logger(loggerFileLabel);
@@ -143,30 +144,6 @@ function isConfigValid(cfg) {
     isActuatorValid;
 
   return isCfgValid;
-}
-
-/**
- * Sets an error on a virtual device in three steps:
- *   - Logs the error message
- *   - Sets an error on each control to turn the entire device red
- *   - Turn off all scenario logic rules by 'vd/rule_enabled' switch
- * @param {Object} vdObj The virtual device object
- * @param {string} errorMsg The error message to log
- */
-function setVdTotalError(vdObj, errorMsg) {
-  if (vdObj === undefined) {
-    log.error('Virtual device does not exist in the system');
-    return;
-  }
-  log.error(errorMsg);
-  vdObj.controlsList().forEach(function (ctrl) {
-    /**
-     * The error type can be 'r', 'w', or 'p'
-     * Our goal is to highlight the control in red
-     */
-    ctrl.setError('r');
-  });
-  vdObj.getControl(vdCtrl.ruleEnabled).setValue(false);
 }
 
 /**
@@ -613,6 +590,7 @@ function init(deviceTitle, cfg) {
       if (!isConfigValid(cfg)) {
         initStatusCtrl.setValue(4);
         setVdTotalError(vdObj, 'Config not valid');
+        vdObj.getControl(vdCtrl.ruleEnabled).setValue(false);
         return;
       }
 
@@ -637,6 +615,7 @@ function init(deviceTitle, cfg) {
         vdObj,
         'Linked controls not ready in ' + (elapsedMs / 1000) + 's.'
       );
+      vdObj.getControl(vdCtrl.ruleEnabled).setValue(false);
     }
   }, checkIntervalMs);
 

--- a/src/virtual-device-helpers.mod.js
+++ b/src/virtual-device-helpers.mod.js
@@ -126,7 +126,6 @@ function toggleRules(managedRulesId, newValue) {
  * Sets an error on a virtual device in three steps:
  *   - Logs the error message
  *   - Sets an error on each control to turn the entire device red
- *   - Turn off all scenario logic rules by 'vd/rule_enabled' switch
  * @param {Object} vdObj The virtual device object
  * @param {string} errorMsg The error message to log
  */

--- a/src/virtual-device-helpers.mod.js
+++ b/src/virtual-device-helpers.mod.js
@@ -13,11 +13,14 @@
  * @returns {boolean} Возвращает true, если контрол существует, иначе false
  */
 function isControlExists(controlName) {
-  var isExist = (dev[controlName] !== null)
+  var isExist = dev[controlName] !== null;
   if (!isExist) {
     log.error(
-      'Control "' + controlName + '" not found, ' +
-      'return value: ' + dev[controlName]
+      'Control "' +
+        controlName +
+        '" not found, ' +
+        'return value: ' +
+        dev[controlName]
     );
     return false;
   }
@@ -42,7 +45,7 @@ function addLinkedControlRO(
   cellBaseName,
   titlePrefix
 ) {
-  if(!isControlExists(srcMqttControl)) return false;
+  if (!isControlExists(srcMqttControl)) return false;
   var cellTitle = titlePrefix + ' ' + srcMqttControl;
   var srcControlType = dev[srcMqttControl + '#type'];
 
@@ -128,7 +131,7 @@ function toggleRules(managedRulesId, newValue) {
  */
 function createBasicVd(vdName, vdTitle, managedRulesId) {
   var ctrlRuleEnabled = 'rule_enabled';
-  var ctrlInitStatus = 'init_status';
+  var ctrlInitStatus = 'state';
 
   var existingVdObj = getDevice(vdName);
   if (existingVdObj !== undefined) {
@@ -164,20 +167,45 @@ function createBasicVd(vdName, vdTitle, managedRulesId) {
 
   controlCfg = {
     title: {
-      en: 'Status',
-      ru: 'Статус',
+      en: 'State',
+      ru: 'Состояние',
     },
-    type: 'text',
-    value: 'Initialisation started...',
+    type: 'value',
     readonly: true,
     forceDefault: true, // Always must start from init string state
+    value: 1,
+    enum: {
+      1: {
+        en: 'Initialisation started...',
+        ru: 'Инициализация запущена...',
+      },
+      2: {
+        en: 'Waiting for linked controls 10s...',
+        ru: 'Ожидание связанных контролов 10с...',
+      },
+      3: {
+        en: 'Linked controls ready',
+        ru: 'Связанные контролы готовы' },
+      4: {
+        en: 'Config not valid',
+        ru: 'Настройки не корректны',
+      },
+      5: {
+        en: 'Linked controls not ready in 10s',
+        ru: 'Связанные контролы не готовы за 10с',
+      },
+      6: {
+        en: 'Normal',
+        ru: 'В норме',
+      },
+    },
     order: 100,
   };
   vdObj.addControl(ctrlInitStatus, controlCfg);
 
   var ruleId = defineRule(vdName + '_change_' + ctrlRuleEnabled, {
     whenChanged: [vdName + '/' + ctrlRuleEnabled],
-    then: function(newValue, devName, cellName) {
+    then: function (newValue, devName, cellName) {
       toggleRules(managedRulesId, newValue);
     },
   });

--- a/src/virtual-device-helpers.mod.js
+++ b/src/virtual-device-helpers.mod.js
@@ -123,6 +123,29 @@ function toggleRules(managedRulesId, newValue) {
 }
 
 /**
+ * Sets an error on a virtual device in three steps:
+ *   - Logs the error message
+ *   - Sets an error on each control to turn the entire device red
+ *   - Turn off all scenario logic rules by 'vd/rule_enabled' switch
+ * @param {Object} vdObj The virtual device object
+ * @param {string} errorMsg The error message to log
+ */
+function setVdTotalError(vdObj, errorMsg) {
+  if (vdObj === undefined) {
+    log.error('Virtual device does not exist in the system');
+    return;
+  }
+  log.error(errorMsg);
+  vdObj.controlsList().forEach(function (ctrl) {
+    /**
+     * The error type can be 'r', 'w', or 'p'
+     * Our goal is to highlight the control in red
+     */
+    ctrl.setError('r');
+  });
+}
+
+/**
  * Creates a basic virtual device with a rule switch if it not already exist
  * @param {string} vdName The name of the virtual device
  * @param {string} vdTitle The title of the virtual device
@@ -223,4 +246,5 @@ exports.addLinkedControlRO = addLinkedControlRO;
 exports.addGroupTitleRO = addGroupTitleRO;
 exports.addAlarm = addAlarm;
 exports.toggleRules = toggleRules;
+exports.setVdTotalError = setVdTotalError;
 exports.createBasicVd = createBasicVd;


### PR DESCRIPTION
Добавлено
- Предварительная переодическая проверка появления связанных топиков до того как запускаем основную инициализацию сценария. Проверка делается каждые 500 мс и если через 10с не появляются связанные топики, или эти топики в ошибке - то выводится ошибка в виртуальном устройстве и в лог. В случае ошибки никакие правила сценария не создаются.
- На время инициализации в виртуальное устройство добавлен контрол отображающий статус и в случае ошибки - отображает ошибку.

Внешний вид во время ожидания инициализации топиков (например если человек опечатался в названии топика или топик действительно не успел появиться и создается другим правилом)
![image](https://github.com/user-attachments/assets/e9c89f26-3398-4b52-a5b5-49440907d47e)

Если после 10 секунд топики не появились - то показывается ошибка
![image](https://github.com/user-attachments/assets/983fe31f-3620-416f-a998-6d660835021d)

Если топики инициализированы успешно и сценарий запушен - поле статуса удаляется
Внешний вид такой
![image](https://github.com/user-attachments/assets/170c1a3d-9fdb-4d9b-86e9-143f6d9f2be2)
