### PR TITLE
Feature/int 271 thermostat change UI

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-scenarios (1.2.1) stable; urgency=medium
+
+  * refactor: change WEBUI configurator text and errors
+
+ -- Vitalii Gaponov <vitalii.gaponov@wirenboard.com>  Mon, 31 Mar 2025 19:00:00 +0300
+
 wb-scenarios (1.2.0) stable; urgency=medium
 
   * feat: implement new scenario thermostat

--- a/scenarios/thermostat/scenario-init-thermostat.js
+++ b/scenarios/thermostat/scenario-init-thermostat.js
@@ -86,7 +86,7 @@ function main() {
   );
   if (!listAllScenarios) return;
 
-  var matchedScenarios = helpers.findAllActiveScenariosWithType(
+  var matchedScenarios = helpers.findAllScenariosWithType(
     listAllScenarios,
     SCENARIO_TYPE_STR,
     REQUIRED_SCENARIO_CFG_VER

--- a/schema/wb-scenarios.schema.json
+++ b/schema/wb-scenarios.schema.json
@@ -84,7 +84,7 @@
           "propertyOrder": 3,
           "options": {
             "grid_columns": 12,
-            "patternmessage": "generalErrorRegexpPatternMessage"
+            "patternmessage": "generalErrorRegexpPatternMessageGeneralType"
           }
         },
         "inControls": {
@@ -116,7 +116,7 @@
                 "pattern": "^[^/+#]+/[^/+#]+$",
                 "_format": "wb-autocomplete",
                 "options": {
-                  "patternmessage": "generalErrorRegexpPatternMessage",
+                  "patternmessage": "generalErrorRegexpPatternMessageMqttTopicName",
                   "inputAttributes": {
                     "placeholder":  "generalMqttTopicNamePlaceholder"
                   },
@@ -174,7 +174,7 @@
                 "pattern": "^[^/+#]+/[^/+#]+$",
                 "_format": "wb-autocomplete",
                 "options": {
-                  "patternmessage": "generalErrorRegexpPatternMessage",
+                  "patternmessage": "generalErrorRegexpPatternMessageMqttTopicName",
                   "inputAttributes": {
                     "placeholder":  "generalMqttTopicNamePlaceholder"
                   },
@@ -300,7 +300,7 @@
           "propertyOrder": 4,
           "options": {
             "grid_columns": 12,
-            "patternmessage": "generalErrorRegexpPatternMessage"
+            "patternmessage": "generalErrorRegexpPatternMessageGeneralType"
           }
         },
         "lightDevices": {
@@ -342,7 +342,7 @@
                     "pattern": "^[^/+#]+/[^/+#]+$",
                     "_format": "wb-autocomplete",
                     "options": {
-                      "patternmessage": "generalErrorRegexpPatternMessage",
+                      "patternmessage": "generalErrorRegexpPatternMessageMqttTopicName",
                       "inputAttributes": {
                         "placeholder":  "generalMqttTopicNamePlaceholder"
                       },
@@ -441,7 +441,7 @@
                     "pattern": "^[^/+#]+/[^/+#]+$",
                     "_format": "wb-autocomplete",
                     "options": {
-                      "patternmessage": "generalErrorRegexpPatternMessage",
+                      "patternmessage": "generalErrorRegexpPatternMessageMqttTopicName",
                       "inputAttributes": {
                         "placeholder":  "generalMqttTopicNamePlaceholder"
                       },
@@ -505,7 +505,7 @@
                     "pattern": "^[^/+#]+/[^/+#]+$",
                     "_format": "wb-autocomplete",
                     "options": {
-                      "patternmessage": "generalErrorRegexpPatternMessage",
+                      "patternmessage": "generalErrorRegexpPatternMessageMqttTopicName",
                       "inputAttributes": {
                         "placeholder":  "generalMqttTopicNamePlaceholder"
                       },
@@ -593,7 +593,7 @@
                     "pattern": "^[^/+#]+/[^/+#]+$",
                     "_format": "wb-autocomplete",
                     "options": {
-                      "patternmessage": "generalErrorRegexpPatternMessage",
+                      "patternmessage": "generalErrorRegexpPatternMessageMqttTopicName",
                       "inputAttributes": {
                         "placeholder":  "generalMqttTopicNamePlaceholder"
                       },
@@ -687,7 +687,7 @@
           "propertyOrder": 3,
           "options": {
             "grid_columns": 12,
-            "patternmessage": "generalErrorRegexpPatternMessage"
+            "patternmessage": "generalErrorRegexpPatternMessageGeneralType"
           }
         },
         "targetTemperature": {
@@ -754,7 +754,7 @@
             "wb": {
               "data": "devices"
             },
-            "patternmessage": "generalErrorRegexpPatternMessage"
+            "patternmessage": "generalErrorRegexpPatternMessageMqttTopicName"
           },
           "minLength": 1
         },
@@ -772,7 +772,7 @@
             "wb": {
               "data": "devices"
             },
-            "patternmessage": "generalErrorRegexpPatternMessage"
+            "patternmessage": "generalErrorRegexpPatternMessageMqttTopicName"
           },
           "minLength": 1
         }
@@ -827,7 +827,8 @@
       "generalMqttTopicNamePlaceholder": "Device/Control",
       "generalBehaviorTypeTitle": "Trigger logic",
       "generalActionValueTitle": "Value",
-      "generalErrorRegexpPatternMessage": "Value must be valid",
+      "generalErrorRegexpPatternMessageGeneralType": "Value must be valid",
+      "generalErrorRegexpPatternMessageMqttTopicName": "The entered value does not match the format <device>/<control>",
       "generalEnumSetValue": "Set Value",
       "generalSensorArrTitle": "Elements list",
 
@@ -885,7 +886,8 @@
       "generalMqttTopicNamePlaceholder": "Устройство/Контрол",
       "generalBehaviorTypeTitle": "Логика срабатывания",
       "generalActionValueTitle": "Значение",
-      "generalErrorRegexpPatternMessage": "Значение должно быть корректным",
+      "generalErrorRegexpPatternMessageGeneralType": "Значение должно быть корректным",
+      "generalErrorRegexpPatternMessageMqttTopicName": "Введённое значение не соответствует формату <устройство>/<контрол>",
       "generalEnumSetValue": "Установить значение",
       "generalSensorArrTitle": "Список элементов",
 

--- a/schema/wb-scenarios.schema.json
+++ b/schema/wb-scenarios.schema.json
@@ -828,7 +828,7 @@
       "generalBehaviorTypeTitle": "Trigger logic",
       "generalActionValueTitle": "Value",
       "generalErrorRegexpPatternMessageGeneralType": "Value must be valid",
-      "generalErrorRegexpPatternMessageMqttTopicName": "The entered value does not match the format <device>/<control>",
+      "generalErrorRegexpPatternMessageMqttTopicName": "Must match the format <device>/<control>",
       "generalEnumSetValue": "Set Value",
       "generalSensorArrTitle": "Elements list",
 
@@ -887,7 +887,7 @@
       "generalBehaviorTypeTitle": "Логика срабатывания",
       "generalActionValueTitle": "Значение",
       "generalErrorRegexpPatternMessageGeneralType": "Значение должно быть корректным",
-      "generalErrorRegexpPatternMessageMqttTopicName": "Введённое значение не соответствует формату <устройство>/<контрол>",
+      "generalErrorRegexpPatternMessageMqttTopicName": "Должно соответствовать формату <устройство>/<контрол>",
       "generalEnumSetValue": "Установить значение",
       "generalSensorArrTitle": "Список элементов",
 

--- a/schema/wb-scenarios.schema.json
+++ b/schema/wb-scenarios.schema.json
@@ -113,11 +113,13 @@
                 "type": "string",
                 "propertyOrder": 1,
                 "title": "generalMqttTopicNameTitle",
-                "description": "generalMqttTopicNameDescription",
                 "pattern": "^[^/+#]+/[^/+#]+$",
                 "_format": "wb-autocomplete",
                 "options": {
                   "patternmessage": "generalErrorRegexpPatternMessage",
+                  "inputAttributes": {
+                    "placeholder":  "generalMqttTopicNamePlaceholder"
+                  },
                   "wb": {
                     "data": "devices"
                   }
@@ -169,11 +171,13 @@
                 "type": "string",
                 "propertyOrder": 1,
                 "title": "generalMqttTopicNameTitle",
-                "description": "generalMqttTopicNameDescription",
                 "pattern": "^[^/+#]+/[^/+#]+$",
                 "_format": "wb-autocomplete",
                 "options": {
                   "patternmessage": "generalErrorRegexpPatternMessage",
+                  "inputAttributes": {
+                    "placeholder":  "generalMqttTopicNamePlaceholder"
+                  },
                   "wb": {
                     "data": "devices"
                   }
@@ -335,11 +339,13 @@
                     "type": "string",
                     "propertyOrder": 1,
                     "title": "generalMqttTopicNameTitle",
-                    "description": "generalMqttTopicNameDescription",
                     "pattern": "^[^/+#]+/[^/+#]+$",
                     "_format": "wb-autocomplete",
                     "options": {
                       "patternmessage": "generalErrorRegexpPatternMessage",
+                      "inputAttributes": {
+                        "placeholder":  "generalMqttTopicNamePlaceholder"
+                      },
                       "wb": {
                         "data": "devices"
                       }
@@ -432,11 +438,13 @@
                     "type": "string",
                     "propertyOrder": 1,
                     "title": "generalMqttTopicNameTitle",
-                    "description": "generalMqttTopicNameDescription",
                     "pattern": "^[^/+#]+/[^/+#]+$",
                     "_format": "wb-autocomplete",
                     "options": {
                       "patternmessage": "generalErrorRegexpPatternMessage",
+                      "inputAttributes": {
+                        "placeholder":  "generalMqttTopicNamePlaceholder"
+                      },
                       "wb": {
                         "data": "devices"
                       }
@@ -494,11 +502,13 @@
                     "type": "string",
                     "propertyOrder": 1,
                     "title": "generalMqttTopicNameTitle",
-                    "description": "generalMqttTopicNameDescription",
                     "pattern": "^[^/+#]+/[^/+#]+$",
                     "_format": "wb-autocomplete",
                     "options": {
                       "patternmessage": "generalErrorRegexpPatternMessage",
+                      "inputAttributes": {
+                        "placeholder":  "generalMqttTopicNamePlaceholder"
+                      },
                       "wb": {
                         "data": "devices"
                       }
@@ -580,11 +590,13 @@
                     "type": "string",
                     "propertyOrder": 1,
                     "title": "generalMqttTopicNameTitle",
-                    "description": "generalMqttTopicNameDescription",
                     "pattern": "^[^/+#]+/[^/+#]+$",
                     "_format": "wb-autocomplete",
                     "options": {
                       "patternmessage": "generalErrorRegexpPatternMessage",
+                      "inputAttributes": {
+                        "placeholder":  "generalMqttTopicNamePlaceholder"
+                      },
                       "wb": {
                         "data": "devices"
                       }
@@ -691,7 +703,6 @@
         "targetTemperature": {
           "type": "number",
           "title": "thermostatTargetTemperatureTitle",
-          "description": "thermostatTargetTemperatureDescription",
           "default": 22,
           "propertyOrder": 4,
           "options": {
@@ -712,7 +723,6 @@
             "min": {
               "type": "number",
               "title": "thermostatTempLimitsMinTitle",
-              "description": "thermostatTempLimitsMinDescription",
               "default": 15,
               "propertyOrder": 1,
               "options": {
@@ -722,7 +732,6 @@
             "max": {
               "type": "number",
               "title": "thermostatTempLimitsMaxTitle",
-              "description": "thermostatTempLimitsMaxDescription",
               "default": 30,
               "propertyOrder": 2,
               "options": {
@@ -745,11 +754,13 @@
           "type": "string",
           "_format": "wb-autocomplete",
           "title": "thermostatTemperatureSensorTitle",
-          "description": "generalMqttTopicNameDescription",
           "pattern": "^[^/+#]+/[^/+#]+$",
           "propertyOrder": 7,
           "options": {
             "grid_columns": 12,
+            "inputAttributes": {
+              "placeholder":  "generalMqttTopicNamePlaceholder"
+            },
             "wb": {
               "data": "devices"
             }
@@ -760,11 +771,13 @@
           "type": "string",
           "_format": "wb-autocomplete",
           "title": "thermostatActuatorTitle",
-          "description": "generalMqttTopicNameDescription",
           "pattern": "^[^/+#]+/[^/+#]+$",
           "propertyOrder": 9,
           "options": {
             "grid_columns": 12,
+            "inputAttributes": {
+              "placeholder":  "generalMqttTopicNamePlaceholder"
+            },
             "wb": {
               "data": "devices"
             }
@@ -816,11 +829,11 @@
     "en": {
       "generalScenarioGenerateRuleTitle": "Activate scenario (creates a virtual device and a scenario rule)",
       "generalScenarioIsDebugEnabled": "Turn on the debug",
-      "generalScenarioName": "Scenario name",
+      "generalScenarioName": "Name",
       "generalScenarioIdPrefixTitle": "MQTT id of the device",
       "generalScenarioIdPrefixDescription": "Used as part of the topic. Only Latin characters, digits and underscore are allowed. Maximum length is 120.",
       "generalMqttTopicNameTitle": "MQTT topic name",
-      "generalMqttTopicNameDescription": "In format: Device/Control",
+      "generalMqttTopicNamePlaceholder": "In format: Device/Control",
       "generalBehaviorTypeTitle": "Trigger logic",
       "generalActionValueTitle": "Value",
       "generalErrorRegexpPatternMessage": "Value must be valid",
@@ -861,27 +874,24 @@
       "lightControlLightSwitchesObjTitle": "Switch",
 
       "thermostatScenarioName": "Thermostat",
-      "thermostatScenarioDescription": "Temperature dependent heater control scenario",
+      "thermostatScenarioDescription": "Maintaining a set temperature with hysteresis",
       "thermostatTargetTemperatureTitle": "Target Temperature (°C)",
-      "thermostatTargetTemperatureDescription": "The temperature value you want the system to maintain. This is the 'target' the device is aiming for.",
-      "thermostatTempLimitsObjTitle": "Virtual device temperature setting limits",
-      "thermostatTempLimitsMinTitle": "Minimum Temperature (°C)",
-      "thermostatTempLimitsMinDescription": "The lowest limit",
-      "thermostatTempLimitsMaxTitle": "Maximum Temperature (°C)",
-      "thermostatTempLimitsMaxDescription": "The highest limit",
+      "thermostatTempLimitsObjTitle": "Temperature adjustment limits in widget",
+      "thermostatTempLimitsMinTitle": "Low (°C)",
+      "thermostatTempLimitsMaxTitle": "Top (°C)",
       "thermostatHysteresisTitle": "Hysteresis (°C)",
-      "thermostatHysteresisDescription": "The range around the set temperature in which the system does not react<br>to changes. It is necessary so that the device does not turn on and off<br>too often, ensuring stable operation.",
-      "thermostatTemperatureSensorTitle": "Temperature sensor",
-      "thermostatActuatorTitle": "Heater"
+      "thermostatHysteresisDescription": "Turn on = Set temperature - Hysteresis.<br>Turn off = Set temperature + Hysteresis.",
+      "thermostatTemperatureSensorTitle": "Temperature channel",
+      "thermostatActuatorTitle": "Heater channel"
     },
     "ru": {
       "generalScenarioGenerateRuleTitle": "Активировать сценарий (создает виртуальное устройство и правило сценария)",
       "generalScenarioIsDebugEnabled": "Включить отладку",
-      "generalScenarioName": "Название сценария",
+      "generalScenarioName": "Наименование",
       "generalScenarioIdPrefixTitle": "Идентификатор устройства в MQTT",
       "generalScenarioIdPrefixDescription": "Используется как часть топика в MQTT, только латинские буквы, цифры и нижнее подчёркивание. Не более 120 символов.",
       "generalMqttTopicNameTitle": "Имя MQTT топика",
-      "generalMqttTopicNameDescription": "В формате: Устройство/Контрол",
+      "generalMqttTopicNamePlaceholder": "В формате: Устройство/Контрол",
       "generalBehaviorTypeTitle": "Логика срабатывания",
       "generalActionValueTitle": "Значение",
       "generalErrorRegexpPatternMessage": "Значение должно быть корректным",
@@ -936,18 +946,15 @@
       "lightControlOpeningSensorsEnumWhenEnabled": "Когда включилось",
 
       "thermostatScenarioName": "Термостат",
-      "thermostatScenarioDescription": "Сценарий управления нагревателем в зависимости от температуры",
+      "thermostatScenarioDescription": "Поддержание заданной температуры с гистерезисом.",
       "thermostatTargetTemperatureTitle": "Заданная температура (°C)",
-      "thermostatTargetTemperatureDescription": "Значение температуры, которое вы хотите поддерживать в системе. Это 'цель', к которой стремится устройство.",
-      "thermostatTempLimitsObjTitle": "Ограничения виртуального устройства на установку температуры",
-      "thermostatTempLimitsMinTitle": "Минимальная температура (°C)",
-      "thermostatTempLimitsMinDescription": "Нижняя граница",
-      "thermostatTempLimitsMaxTitle": "Максимальная температура (°C)",
-      "thermostatTempLimitsMaxDescription": "Верхняя граница",
+      "thermostatTempLimitsObjTitle": "Границы изменения температуры в виджете",
+      "thermostatTempLimitsMinTitle": "Нижняя (°C)",
+      "thermostatTempLimitsMaxTitle": "Верхняя (°C)",
       "thermostatHysteresisTitle": "Гистерезис (°C)",
-      "thermostatHysteresisDescription": "Диапазон вокруг заданной температуры, в котором система не реагирует на<br>изменения. Он нужен, чтобы устройство не включалось и выключалось слишком<br>часто, обеспечивая стабильную работу.",
-      "thermostatTemperatureSensorTitle": "Датчик температуры",
-      "thermostatActuatorTitle": "Нагреватель"
+      "thermostatHysteresisDescription": "Включение = Заданная температура - Гистерезис.<br>Выключение = Заданная температура + Гистерезис.",
+      "thermostatTemperatureSensorTitle": "Канал температуры",
+      "thermostatActuatorTitle": "Канал нагревателя"
     }
   }
 }

--- a/schema/wb-scenarios.schema.json
+++ b/schema/wb-scenarios.schema.json
@@ -664,16 +664,6 @@
             "hidden": true
           }
         },
-        "enable": {
-          "type": "boolean",
-          "title": "generalScenarioGenerateRuleTitle",
-          "default": true,
-          "_format": "checkbox",
-          "propertyOrder": 1,
-          "options": {
-            "grid_columns": 12
-          }
-        },
         "name": {
           "type": "string",
           "title": "generalScenarioName",
@@ -788,7 +778,6 @@
       "required": [
         "scenarioType",
         "componentVersion",
-        "enable",
         "name",
         "targetTemperature",
         "temperatureLimits",

--- a/schema/wb-scenarios.schema.json
+++ b/schema/wb-scenarios.schema.json
@@ -828,7 +828,7 @@
       "generalBehaviorTypeTitle": "Trigger logic",
       "generalActionValueTitle": "Value",
       "generalErrorRegexpPatternMessageGeneralType": "Value must be valid",
-      "generalErrorRegexpPatternMessageMqttTopicName": "Must match the format <device>/<control>",
+      "generalErrorRegexpPatternMessageMqttTopicName": "Does not match the format <device>/<control>",
       "generalEnumSetValue": "Set Value",
       "generalSensorArrTitle": "Elements list",
 
@@ -887,7 +887,7 @@
       "generalBehaviorTypeTitle": "Логика срабатывания",
       "generalActionValueTitle": "Значение",
       "generalErrorRegexpPatternMessageGeneralType": "Значение должно быть корректным",
-      "generalErrorRegexpPatternMessageMqttTopicName": "Должно соответствовать формату <устройство>/<контрол>",
+      "generalErrorRegexpPatternMessageMqttTopicName": "Не соответствует формату <устройство>/<контрол>",
       "generalEnumSetValue": "Установить значение",
       "generalSensorArrTitle": "Список элементов",
 

--- a/schema/wb-scenarios.schema.json
+++ b/schema/wb-scenarios.schema.json
@@ -753,7 +753,8 @@
             },
             "wb": {
               "data": "devices"
-            }
+            },
+            "patternmessage": "generalErrorRegexpPatternMessage"
           },
           "minLength": 1
         },
@@ -770,7 +771,8 @@
             },
             "wb": {
               "data": "devices"
-            }
+            },
+            "patternmessage": "generalErrorRegexpPatternMessage"
           },
           "minLength": 1
         }
@@ -822,7 +824,7 @@
       "generalScenarioIdPrefixTitle": "MQTT id of the device",
       "generalScenarioIdPrefixDescription": "Used as part of the topic. Only Latin characters, digits and underscore are allowed. Maximum length is 120.",
       "generalMqttTopicNameTitle": "MQTT topic name",
-      "generalMqttTopicNamePlaceholder": "In format: Device/Control",
+      "generalMqttTopicNamePlaceholder": "Device/Control",
       "generalBehaviorTypeTitle": "Trigger logic",
       "generalActionValueTitle": "Value",
       "generalErrorRegexpPatternMessage": "Value must be valid",
@@ -880,7 +882,7 @@
       "generalScenarioIdPrefixTitle": "Идентификатор устройства в MQTT",
       "generalScenarioIdPrefixDescription": "Используется как часть топика в MQTT, только латинские буквы, цифры и нижнее подчёркивание. Не более 120 символов.",
       "generalMqttTopicNameTitle": "Имя MQTT топика",
-      "generalMqttTopicNamePlaceholder": "В формате: Устройство/Контрол",
+      "generalMqttTopicNamePlaceholder": "Устройство/Контрол",
       "generalBehaviorTypeTitle": "Логика срабатывания",
       "generalActionValueTitle": "Значение",
       "generalErrorRegexpPatternMessage": "Значение должно быть корректным",

--- a/src/scenarios-general-helpers.mod.js
+++ b/src/scenarios-general-helpers.mod.js
@@ -11,6 +11,41 @@ var Logger = require('logger.mod').Logger;
 var log = new Logger('WBSC-helper');
 
 /**
+ * Finds and returns all scenarios of the specified type
+ * @param {Array} listScenario An array of all scenarios from the config
+ * @param {string} searchScenarioType The type of scenario to search for
+ * @param {number} reqScenarioCfgVer The configuration version number
+ *     for the specific scenario type
+ * @returns {Array} An array of scenarios with type searchScenarioType
+ */
+function findAllScenariosWithType(
+  listScenario,
+  searchScenarioType,
+  reqScenarioCfgVer
+) {
+  var matchedScenarios = [];
+  for (var i = 0; i < listScenario.length; i++) {
+    var scenario = listScenario[i];
+    if (scenario.scenarioType !== searchScenarioType) {
+      continue;
+    }
+
+    if (scenario.componentVersion !== reqScenarioCfgVer) {
+      log.error(
+        'Scenario with name "{}" cfg ver mismatch. Expected: "{}", got: "{}"',
+        scenario.name,
+        reqScenarioCfgVer,
+        scenario.componentVersion
+      );
+      continue;
+    }
+    matchedScenarios.push(scenario);
+  }
+
+  return matchedScenarios;
+}
+
+/**
  * Finds and returns all enabled scenarios of the specified type
  * @param {Array} listScenario An array of all scenarios from the config
  * @param {string} searchScenarioType The type of scenario to search for
@@ -119,6 +154,7 @@ function getIdPrefix(deviceTitle, cfg) {
   return idPrefix;
 }
 
+exports.findAllScenariosWithType = findAllScenariosWithType;
 exports.findAllActiveScenariosWithType = findAllActiveScenariosWithType;
 exports.readAndValidateScenariosConfig = readAndValidateScenariosConfig;
 exports.getIdPrefix = getIdPrefix;


### PR DESCRIPTION
Реализованы изменения в UI которые потребовались для улучшения восприятия конфигуратора

Во всех сценариях:
- Пояснение формата ввода данных топиков перенесено из description в placeholder

Для сценария термостата:
- В схеме изменены и удалены некоторые пункты по тексту
- В схеме удален флажек enable - так же для этого изменен файл инициализации сценария термостата, так как теперь мы выбираем не только активные сценарии нужного типа, а все сценарии без разбора.

Что не сделал:
- Слова слева от выпадающего списка не получится изменить только схемой, нужно менять json-editor для этого.

Было/стало по тексту приложил в скринах

Цветом выделены изменения на которые стоит обратить внимание
![image](https://github.com/user-attachments/assets/f955c496-633c-4c14-bdd5-05fb879d9909)

Новый вид конфигуратора после PR:
![image](https://github.com/user-attachments/assets/d861c080-d746-4ee4-99a4-8cc4dea1afa1)