### PR TITLE
(DRAFT!) fix: add processing for external light control

### DIFF
--- a/scenarios/light-control/light-control.mod.js
+++ b/scenarios/light-control/light-control.mod.js
@@ -804,10 +804,11 @@ LightControlScenario.prototype.initSpecific = function (deviceTitle, cfg) {
   }
 
   /**
-   * Проверка - все ли датчики открытия замкнуты (двери закрыты)
+   * Check if all opening sensors are closed (doors are closed)
    *
-   * @returns {boolean} true, если все датчики показывают,
-   *     что двери закрыты, иначе false
+   * @returns {boolean} Complex status for all sensors:
+   *   - true if all sensors show that doors are closed
+   *   - false otherwise
    */
   function checkAllOpeningSensorsClose() {
     for (var i = 0; i < cfg.openingSensors.length; i++) {
@@ -820,11 +821,11 @@ LightControlScenario.prototype.initSpecific = function (deviceTitle, cfg) {
         curSensorState
       );
       if (isOpen === true) {
-        // Если хотя бы один датчик активен (дверь открыта), возвращаем false
+        // If at least one sensor is active (door is open), return false
         return false;
       }
     }
-    return true; // Все датчики пассивны (двери закрыты)
+    return true; // All sensors are passive (doors are closed)
   }
 
   /**

--- a/scenarios/light-control/light-control.mod.js
+++ b/scenarios/light-control/light-control.mod.js
@@ -759,36 +759,49 @@ LightControlScenario.prototype.initSpecific = function (deviceTitle, cfg) {
     return sensorTriggered;
   }
 
+
   /**
-   * Проверка - активен ли датчик открытия (дверь открыта или закрыта)
-   *     на основе поведения
+   * @typedef {Object} SensorConfig
+   * @property {string} mqttTopicName - MQTT topic name for the sensor
+   * @property {string} behaviorType - Sensor behavior type
+   *   - whenEnabled
+   *   - whenDisabled
+   * @property {string} [description] - Optional description of the sensor
+   */
+
+  /**
+   * Check if opening sensor is triggered (door is open or closed)
+   * based on behavior type
    *
-   * @param {Object} sensorWithBehavior Объект датчика
-   *     (содержит behaviorType и другие свойства)
-   * @param {any} newValue Текущее состояние датчика
-   * @returns {boolean} true, если датчик активен (дверь открыта), иначе false
+   * @param {SensorConfig} sensorWithBehavior - Sensor object
+   *     (contains behaviorType and other properties)
+   * @param {boolean|string} newValue - Current sensor state
+   * @returns {boolean} Triggered status based on behavior type
+   *   - true if sensor is triggered (door is open)
+   *   - false otherwise
    */
   function isOpeningSensorOpenedByBehavior(sensorWithBehavior, newValue) {
     if (sensorWithBehavior.behaviorType === 'whenDisabled') {
       /**
-       * Датчик нормально замкнутый:
-       *   - При закрытой двери - нормальное состояние true
-       *   - Когда дверь открыта - разомкнут, состояние false
+       * Normally closed sensor:
+       *   - When door is closed - normal state is true
+       *   - When door is open - disconnected, state is false
        */
       return newValue === false || newValue === 'false';
     } else if (sensorWithBehavior.behaviorType === 'whenEnabled') {
       /**
-       * Датчик нормально разомкнутый:
-       *   - При закрытой двери - нормальное состояние false
-       *   - Когда дверь открыта - замыкается, состояние true
+       * Normally open sensor:
+       *   - When door is closed - normal state is false
+       *   - When door is open - connected, state is true
        */
       return newValue === true || newValue === 'true';
     } else {
+      // Consider unknown behavior as inactive
       log.error(
-        'Unknown behavior type for sensor: ' +
-          sensorWithBehavior.mqttTopicName
+        'Unknown behavior type for sensor: "{}"',
+        sensorWithBehavior.mqttTopicName
       );
-      return false; // Считаем неизвестное поведение неактивным
+      return false;
     }
   }
 

--- a/scenarios/light-control/light-control.mod.js
+++ b/scenarios/light-control/light-control.mod.js
@@ -715,6 +715,29 @@ LightControlScenario.prototype.initSpecific = function (deviceTitle, cfg) {
   }
 
   /**
+   * Find topic configuration in the specified configuration array
+   *
+   * @param {string} topicName - Topic name to search for
+   * @param {SensorConfig[]} configArray - Array of configurations to search in
+   * @returns {SensorConfig|null} Found topic configuration or null if not found
+   */
+  function findTopicConfig(topicName, configArray) {
+    if (!configArray || !Array.isArray(configArray)) {
+      log.error('Invalid config array provided for topic search: ' + topicName);
+      return null;
+    }
+    
+    for (var i = 0; i < configArray.length; i++) {
+      if (configArray[i].mqttTopicName === topicName) {
+        return configArray[i];
+      }
+    }
+    
+    log.error('Cannot find config for topic: ' + topicName);
+    return null;
+  }
+
+  /**
    * Проверка - находится ли датчик в активном состоянии
    *   У разных типов контролов будет разная логика определения
    *   'активного' состояния:

--- a/scenarios/light-control/light-control.mod.js
+++ b/scenarios/light-control/light-control.mod.js
@@ -739,9 +739,7 @@ LightControlScenario.prototype.initSpecific = function (deviceTitle, cfg) {
         sensorTriggered = false;
       }
     } else if (sensorWithBehavior.behaviorType === 'whenEnabled') {
-      if (newValue === true) {
-        sensorTriggered = true;
-      } else if (newValue === 'true') {
+      if (newValue === true || newValue === 'true') {
         sensorTriggered = true;
       } else if (newValue === false || newValue === 'false') {
         sensorTriggered = false;
@@ -1182,6 +1180,7 @@ LightControlScenario.prototype.initSpecific = function (deviceTitle, cfg) {
 
   function openingSensorTriggeredLaunchCb(topicObj, eventObj) {
     // Тригерит только изменение выбранное пользователем
+    // If any door open - we enable control '/doorOpen'
     dev[self.genNames.vDevice + '/doorOpen'] = true;
 
     return true;
@@ -1189,6 +1188,7 @@ LightControlScenario.prototype.initSpecific = function (deviceTitle, cfg) {
 
   function openingSensorTriggeredResetCb(topicObj, eventObj) {
     // Тригерит только противоположное действие
+    // Only if all doors closec - we disable control '/doorOpen'
     if (checkAllOpeningSensorsClose()) {
       dev[self.genNames.vDevice + '/doorOpen'] = false;
     } else {

--- a/scenarios/light-control/light-control.mod.js
+++ b/scenarios/light-control/light-control.mod.js
@@ -175,10 +175,10 @@ LightControlScenario.prototype.initSpecific = function (deviceTitle, cfg) {
   addCustomCellsToVd();
 
   // Предварительно извлекаем имена контролов
-  var lightDevicesControlNames = extractControlNames(cfg.lightDevices);
-  var motionSensorsControlNames = extractControlNames(cfg.motionSensors);
-  var openingSensorsControlNames = extractControlNames(cfg.openingSensors);
-  var lightSwitchesControlNames = extractControlNames(cfg.lightSwitches);
+  var lightDevicesControlNames = extractMqttTopics(cfg.lightDevices);
+  var motionSensorsControlNames = extractMqttTopics(cfg.motionSensors);
+  var openingSensorsControlNames = extractMqttTopics(cfg.openingSensors);
+  var lightSwitchesControlNames = extractMqttTopics(cfg.lightSwitches);
 
   tm.registerSingleEvent(
     lightDevicesControlNames,
@@ -1126,7 +1126,7 @@ LightControlScenario.prototype.initSpecific = function (deviceTitle, cfg) {
   }
 
   //Извлечение имен контролов (mqttTopicName) из массива
-  function extractControlNames(devices) {
+  function extractMqttTopics(devices) {
     var result = [];
     for (var i = 0; i < devices.length; i++) {
       result.push(devices[i].mqttTopicName);

--- a/scenarios/light-control/light-control.mod.js
+++ b/scenarios/light-control/light-control.mod.js
@@ -9,17 +9,10 @@
 var ScenarioBase = require('scenario-base.mod').ScenarioBase;
 var vdHelpers = require('virtual-device-helpers.mod');
 var aTable = require('registry-action-resolvers.mod');
-
-var TopicManager = require('tm-main.mod').TopicManager;
-var eventPlugin = require('tm-event-main.mod').eventPlugin;
-var historyPlugin = require('tm-history-main.mod').historyPlugin;
 var Logger = require('logger.mod').Logger;
 
 var log = new Logger('WBSC‑light');
 
-var tm = new TopicManager();
-tm.installPlugin(historyPlugin);
-tm.installPlugin(eventPlugin);
 
 var lastActionType = {
   NOT_USED       : 0, // Not used yet (set immediately after start)

--- a/scenarios/light-control/light-control.mod.js
+++ b/scenarios/light-control/light-control.mod.js
@@ -174,14 +174,13 @@ LightControlScenario.prototype.initSpecific = function (deviceTitle, cfg) {
   log.debug('Start rules creation');
   addCustomCellsToVd();
 
-  // Предварительно извлекаем имена контролов
-  var lightDevicesControlNames = extractMqttTopics(cfg.lightDevices);
-  var motionSensorsControlNames = extractMqttTopics(cfg.motionSensors);
-  var openingSensorsControlNames = extractMqttTopics(cfg.openingSensors);
-  var lightSwitchesControlNames = extractMqttTopics(cfg.lightSwitches);
+  var lightDevTopics = extractMqttTopics(cfg.lightDevices);
+  var motionTopics = extractMqttTopics(cfg.motionSensors);
+  var openingTopics = extractMqttTopics(cfg.openingSensors);
+  var switchTopics = extractMqttTopics(cfg.lightSwitches);
 
   tm.registerSingleEvent(
-    lightDevicesControlNames,
+    lightDevTopics,
     'whenChange',
     lightDevicesCb
   );
@@ -216,7 +215,7 @@ LightControlScenario.prototype.initSpecific = function (deviceTitle, cfg) {
     lightOnCb
   );
   tm.registerMultipleEvents(
-    lightSwitchesControlNames,
+    switchTopics,
     'whenChange',
     lightSwitchUsedCb
   );
@@ -236,7 +235,7 @@ LightControlScenario.prototype.initSpecific = function (deviceTitle, cfg) {
 
   // Создаем правило для датчиков движения
   var ruleIdMotion = defineRule(self.genNames.ruleMotion, {
-    whenChanged: motionSensorsControlNames,
+    whenChanged: motionTopics,
     then: function (newValue, devName, cellName) {
       sensorTriggeredHandler(newValue, devName, cellName, 'motion');
     },
@@ -252,7 +251,7 @@ LightControlScenario.prototype.initSpecific = function (deviceTitle, cfg) {
 
   // Создаем правило для датчиков открытия
   var ruleIdOpening = defineRule(self.genNames.ruleOpening, {
-    whenChanged: openingSensorsControlNames,
+    whenChanged: openingTopics,
     then: function (newValue, devName, cellName) {
       sensorTriggeredHandler(newValue, devName, cellName, 'opening');
     },

--- a/scenarios/light-control/scenario-init-light-control.js
+++ b/scenarios/light-control/scenario-init-light-control.js
@@ -1,14 +1,20 @@
 /**
- * @file Скрипт для инициализации сценариев с типом SCENARIO_TYPE
- * @overview Этот скрипт:
- *             - Загружает все конфигурации сценарииев с типом
- *               SCENARIO_TYPE из файла
- *             - Находит все активные сценарии данного типа
- *             - Инициализирует их согласно настройкам, указанным
- *               в каждом сценарии
+ * @file init-light-control.js - script for WirenBoard wb-rules v2.28.4
+ * @description Script for init scenarios of the SCENARIO_TYPE type
+ *     This script:
+ *     - Loads all scenario configurations of the specific type from a file
+ *     - Finds all active scenarios of this type
+ *     - Initializes them according to the settings specified in each scenario
+ *
  * @author Vitalii Gaponov <vitalii.gaponov@wirenboard.com>
- * @link Комментарии в формате JSDoc <https://jsdoc.app/>
+ * @link Comments formatted in JSDoc <https://jsdoc.app/> - Google styleguide
  */
+
+var scGenHelpers = require('scenarios-general-helpers.mod');
+var LightControlSc  = require('light-control.mod').LightControlScenario;
+var Logger = require('logger.mod').Logger;
+
+var log = new Logger('WBSC-light-init');
 
 /**
  * Требуемая версия общей структуры файла конфигурации сценариев
@@ -38,40 +44,34 @@ var CONFIG_PATH = '/etc/wb-scenarios.conf';
  */
 var SCENARIO_TYPE = 'lightControl';
 
-var scGenHelpers = require('scenarios-general-helpers.mod');
-var lightControl = require('light-control.mod');
-
 /**
  * Инициализирует сценарий с использованием указанных настроек
- * @param {object} scenario - Объект сценария, содержащий настройки
+ * @param {object} scenarioCfg - Объект сценария, содержащий настройки
  * @returns {void}
  */
-function initializeScenario(scenario) {
-  log.debug('Processing scenario: ' + JSON.stringify(scenario));
+function initializeScenario(scenarioCfg) {
+  log.debug('Processing scenario: ' + JSON.stringify(scenarioCfg));
 
   var cfg = {
-    idPrefix: scenario.id_prefix,
-    isDebugEnabled: scenario.isDebugEnabled,
-    delayByMotionSensors: scenario.motionSensors.delayToLightOff,
-    delayByOpeningSensors: scenario.openingSensors.delayToLightOff,
-    isDelayEnabledAfterSwitch: scenario.lightSwitches.isDelayEnabled,
-    delayBlockAfterSwitch: scenario.lightSwitches.delayToLightOffAndEnable,
-    lightDevices: scenario.lightDevices.sensorObjects,
-    motionSensors: scenario.motionSensors.sensorObjects,
-    openingSensors: scenario.openingSensors.sensorObjects,
-    lightSwitches: scenario.lightSwitches.sensorObjects,
+    idPrefix: scenarioCfg.id_prefix,
+    isDebugEnabled: scenarioCfg.isDebugEnabled,
+    delayByMotionSensors: scenarioCfg.motionSensors.delayToLightOff,
+    delayByOpeningSensors: scenarioCfg.openingSensors.delayToLightOff,
+    isDelayEnabledAfterSwitch: scenarioCfg.lightSwitches.isDelayEnabled,
+    delayBlockAfterSwitch: scenarioCfg.lightSwitches.delayToLightOffAndEnable,
+    lightDevices: scenarioCfg.lightDevices.sensorObjects,
+    motionSensors: scenarioCfg.motionSensors.sensorObjects,
+    openingSensors: scenarioCfg.openingSensors.sensorObjects,
+    lightSwitches: scenarioCfg.lightSwitches.sensorObjects,
   };
-  var isInitSucess = lightControl.init(scenario.name, cfg);
-
+  var scenario = new LightControlSc();
+  var isInitSucess = scenario.init(scenarioCfg.name, cfg);
   if (!isInitSucess) {
-    log.error(
-      'Error: Init operation aborted for scenario with "idPrefix": ' +
-        scenario.id_prefix
-    );
+    log.error('Init aborted for idPrefix=' + scenarioCfg.id_prefix);
     return;
   }
 
-  log.debug('Initialization successful for: ' + scenario.name);
+  log.debug('Initialization successful for: ' + scenarioCfg.name);
 }
 
 function main() {

--- a/src/scenario-base.mod.js
+++ b/src/scenario-base.mod.js
@@ -1,0 +1,143 @@
+/**
+ * @file scenario-base.mod.js
+ * @description Minimal abstract ES5 base class for all WB‑rules scenarios
+ */
+
+var getIdPrefix = require('scenarios-general-helpers.mod').getIdPrefix;
+var createBasicVd = require('virtual-device-helpers.mod').createBasicVd;
+var setVdTotalError = require('virtual-device-helpers.mod').setVdTotalError;
+var Logger    = require('logger.mod').Logger;
+
+var log = new Logger('WBSC‑base');
+
+/**
+ * Abstract base class every scenario must extend
+ * @abstract Should not be instantiated directly, only inherited
+ * @constructor
+ */
+function ScenarioBase() {
+  if (this.constructor === ScenarioBase) {
+    throw new Error('ScenarioBase is abstract class – extend it by child');
+  }
+
+  // Basic properties that will be set during initialization
+  this.name = null;
+  this.cfg = null;
+  this.idPrefix = null;  // 'translit(name)' or 'cfg.idPrefix' if set by user
+  this.genNames    = null;  // generated names (vd‑id, rule‑id’s …)
+  this.vd = null;  // Automatically created scenario virtual device
+
+  // Internal state
+  this._rules = [];  // Collection of rule IDs for management
+  this._initialized = false;
+}
+
+/**
+ * Initialize the scenario with name and configuration
+ * 
+ * @note This is single entry point called by user code.
+ *       Do not override unless you really need.
+ * @param {string} name Scenario title / virtual‑device title
+ * @param {Object} cfg Raw configuration object supplied by user
+ * @returns {boolean} True on success, throws on error
+ */
+ScenarioBase.prototype.init = function(name, cfg) {
+  if (this._initialized) {
+    throw new Error('Scenario already initialized');
+  }
+
+  this.name = name;
+  this.cfg = cfg;
+  this.idPrefix = getIdPrefix(name, cfg);
+
+  if (this.generateNames === ScenarioBase.prototype.generateNames) {
+    throw new Error('generateNames() must be implemented in subclass');
+  }
+  if (this.validateCfg === ScenarioBase.prototype.validateCfg) {
+    throw new Error('validateCfg() must be implemented in subclass');
+  }
+  if (this.initSpecific === ScenarioBase.prototype.initSpecific) {
+    throw new Error('initSpecific(cfg) must be implemented in subclass');
+  }
+
+  this.genNames = this.generateNames(this.idPrefix);
+  this.vd = createBasicVd(
+    this.genNames.vDevice,
+    this.name,
+    this._rules);
+  if (!this.vd) throw new Error('Basic VD creation failed');
+
+  if (this.validateCfg(cfg) !== true) {
+    this.setTotalError('Config validation failed');
+    throw new Error('Config validation failed "' + this.name + '"');
+  }
+  log.debug('All checks pass successfuly!');
+
+  var ok = this.initSpecific(name, cfg);
+  if (ok === false) {
+    this.setTotalError('initSpecific() returned false');
+    throw new Error('initSpecific() returned false');
+  }
+
+  // TODO:(vg) write optional wait topics and call initAfterWait()
+  //           if we need wait - _initialized must be set after wait?
+
+  this._initialized = true;
+  log.info('[{}] Scenario initialized successfully', this.name);
+  return true;
+};
+
+/**
+ * Convenience wrapper to collect rule IDs created inside subclasses.
+ *
+ * @param {number} id  ID from defineRule
+ */
+ScenarioBase.prototype.addRule = function (id) {
+  this._rules.push(id);
+};
+
+ScenarioBase.prototype.setTotalError = function (msg) {
+    if (this.vd) setVdTotalError(this.vd, msg);
+    else log.error('[{}] {}', this.name || 'Unknown', msg);
+  };
+
+/* ------------------------------------------------------------------ */
+/*        Abstract methods stubs — MUST be overridden                 */
+/* ------------------------------------------------------------------ */
+
+
+/**
+ * Build map with virtual‑device id, rule names, etc.
+ * @abstract
+ * @param   {string} idPrefix Transliteration of scenario title
+ * @returns {Object}
+ */
+ScenarioBase.prototype.generateNames = function () {
+    throw new Error('generateNames() must be overridden by derived class');
+};
+
+/**
+ * Validate configuration object before logic creation
+ * Should throw/return false if cfg is invalid
+ *
+ * @abstract
+ * @param   {Object} cfg  Raw configuration
+ * @returns {boolean}     True if configuration is acceptable
+ */
+ScenarioBase.prototype.validateCfg = function () {
+  throw new Error('validateCfg() must be overridden by derived class');
+  // If all OK - must return - true
+};
+
+/**
+ * Create all rules, virtual devices, timers, etc.
+ * Must be implemented in subclass. Use {@link addRule} to
+ * store rule IDs if you need later clean‑up.
+ *
+ * @abstract
+ */
+ScenarioBase.prototype.initSpecific = function () {
+  throw new Error('initSpecific() must be overridden by derived class');
+};
+
+exports.ScenarioBase = ScenarioBase;

--- a/src/translit.mod.js
+++ b/src/translit.mod.js
@@ -66,7 +66,7 @@ function replaceChar(char) {
  *     with valid characters only
  */
 function translit(input) {
-  return input
+  id = input
     .toLowerCase()
     .split('')
     .map(replaceChar)             // Replaces non-Latin symbols to latin char
@@ -74,6 +74,15 @@ function translit(input) {
     .replace(/[^a-z0-9_]/g, '_')  // Replaces unsupported characters with '_'
     .replace(/_+/g, '_')          // Replace multiple '_' with a single one
     .replace(/^_+|_+$/g, '');     // Remove leading and trailing '_'
+
+  // Default ID if empty after processing
+  log.error(
+    'Transliteration failed for input "{}" — fallback to "scenario"',
+    input
+  );
+  if (!id) id = 'scenario';
+  
+  return id;
 }
 
 exports.translit = function (input) {


### PR DESCRIPTION
# (DRAFT!)

___________________________________
**Что происходит; кому и зачем нужно:**

При реализации логики работы с одним и тем же освещением, например
- Из сценария управления девайсами - мастер выключатель
- Из сценария управления светом - управление например в туалете по датчику движения и настенным выключателем

Возникала проблема того, что мы не учитывали раньше возможность внешнего управления
Для того чтобы учесть это внешнее управление - был добавлен новый контрол в список виртуальных устройсв, который показывает тип последнего переключения.

![image](https://github.com/user-attachments/assets/a2b063b0-48de-401d-b5cf-613d962fcc2c)


___________________________________
**Что поменялось для пользователей:**

Теперь нет проблем блокировки внешнего управляемого ресурса (ламп) - можно после внешнего выключения сразу управлять
- Корректно отображается статус light on - раньше он не изменялся если выключен вшенше
![image](https://github.com/user-attachments/assets/f345a9e7-7ec4-4a7c-b539-742707efa4cb)
- Корректно сбрасываются счетчики ожидания отключения света если свет был включен датчиком движения и потом выключен мастер выключателем
- Корректно сбрасываются блокировки автоматизации если свет был включен настенным выключателем и далее выключен мастер выключателем

___________________________________
**Как проверял/а:**

Установил локально на свой контроллер и проверял в вебке виртуальными устрйоствами с реальным msw, реле и тд


