### PR TITLE
feat: add light init script + base module

### DIFF
--- a/scenarios/light-control/light-control.mod.js
+++ b/scenarios/light-control/light-control.mod.js
@@ -1,0 +1,102 @@
+/**
+ * @file light-control.mod.js - ES5 module for wb-rules v2.28
+ * @description Light control scenario class that extends ScenarioBase
+ *
+ * @author Vitalii Gaponov <vitalii.gaponov@wirenboard.com>
+ */
+
+var ScenarioBase = require('wbsc-scenario-base.mod').ScenarioBase;
+var Logger = require('logger.mod').Logger;
+
+var loggerFileLabel = 'WBSC-light-control-mod';
+var log = new Logger(loggerFileLabel);
+
+/**
+ * @typedef {Object} LightControlConfig
+ * @property {string} [idPrefix] - Optional prefix for scenario identification
+ *   If not provided, it will be generated from the scenario name
+ * @property {Array<Object>} lightDevices - Array of light devices to control
+ * @property {Array<Object>} motionSensors - Array of motion sensors
+ * @property {Array<Object>} openingSensors - Array of opening sensors
+ * @property {Array<Object>} lightSwitches - Array of manual light switches
+ * @property {boolean} [isDebugEnabled] - Enable debug mode with extra VD ctrl
+ * @property {number} [delayByMotionSensors] - Delay (s) before turning off
+ *   lights after motion stops
+ * @property {number} [delayByOpeningSensors] - Delay (s) before turning off
+ *   lights after door closes
+ * @property {boolean} [isDelayEnabledAfterSwitch] - Enable auto-off delay after
+ *   manual switch usage
+ * @property {number} [delayBlockAfterSwitch] - Delay (s) before automation
+ *   resumes after manual control
+ */
+
+/**
+ * Light control scenario implementation
+ * @class LightControlScenario
+ * @extends ScenarioBase
+ */
+function LightControlScenario() {
+  ScenarioBase.call(this);
+}
+LightControlScenario.prototype = Object.create(ScenarioBase.prototype);
+LightControlScenario.prototype.constructor = LightControlScenario;
+
+/**
+ * Generates name identifiers for virtual device and rules
+ * @param {string} idPrefix - ID prefix for this scenario instance
+ * @returns {Object} Generated names
+ */
+LightControlScenario.prototype.generateNames = function (idPrefix) {
+  var scenarioPrefix = 'wbsc_';
+  var baseRuleName = scenarioPrefix + idPrefix;
+
+  return {
+    vDevice: scenarioPrefix + idPrefix,
+    ruleLightOnChange: baseRuleName + 'lightOnChange',
+  };
+};
+
+/**
+ * Configuration validation stub - will be implemented in future PRs
+ * @param {LightControlConfig} cfg - Configuration object
+ * @returns {boolean} Always returns true in this first implementation
+ */
+LightControlScenario.prototype.validateCfg = function (cfg) {
+  return true;
+};
+
+/**
+ * Scenario initialization
+ * @param {string} deviceTitle - Virtual device title
+ * @param {LightControlConfig} cfg - Configuration object
+ * @returns {boolean} True if initialization succeeded
+ */
+LightControlScenario.prototype.initSpecific = function (deviceTitle, cfg) {
+  log.debug('Start init light scenario');
+  log.setLabel(loggerFileLabel + '/' + this.idPrefix);
+  // Add basic lightOn control
+  this.vd.devObj.addControl('lightOn', {
+    title: {
+      en: 'Light On',
+      ru: 'Освещение включено',
+    },
+    type: 'switch',
+    value: false,
+    readonly: true,
+    order: 2,
+  });
+
+  // Create a simple rule as a placeholder
+  var ruleId = defineRule(this.genNames.ruleLightOnChange, {
+    whenChanged: [this.genNames.vDevice + '/lightOn'],
+    then: function (newValue) {
+      log.debug('Light state changed to: ' + newValue);
+    },
+  });
+
+  this.addRule(ruleId);
+  log.debug('Light control scenario initialized');
+  return true;
+};
+
+exports.LightControlScenario = LightControlScenario;

--- a/scenarios/light-control/scenario-init-light-control.js
+++ b/scenarios/light-control/scenario-init-light-control.js
@@ -1,0 +1,101 @@
+/**
+ * @file init-light-control.js - ES5 script for wb-rules v2.28
+ * @description Script for init scenarios of the SCENARIO_TYPE_STR type
+ *     This script:
+ *     - Loads all scenario configurations of the specific type from a file
+ *     - Initializes them according to the settings specified in each scenario
+ *
+ * @author Vitalii Gaponov <vitalii.gaponov@wirenboard.com>
+ */
+
+var scHelpers = require('scenarios-general-helpers.mod');
+var CustomTypeSc = require('light-control.mod').LightControlScenario;
+var Logger = require('logger.mod').Logger;
+
+/**
+ * Scenario initialization configuration parameters
+ * @typedef {Object} ScenarioConfig
+ */
+var CFG = {
+  reqVerGeneralCfg: 1, // Required version of common config structure
+  reqVerScenario: 2, // Required version of this scenario type config
+  configPath: '/etc/wb-scenarios.conf',
+  scenarioTypeStr: 'lightControl',
+};
+
+var log = new Logger('WBSC-' + CFG.scenarioTypeStr + '-init');
+
+/**
+ * Initializes a scenario using the specified settings
+ * @param {object} scenarioCfg - The scenario object containing the settings
+ * @returns {void}
+ */
+function initializeScenario(scenarioCfg) {
+  log.debug('Processing scenario config: "{}"', JSON.stringify(scenarioCfg));
+
+  var scenario = new CustomTypeSc();
+  var cfg = {
+    idPrefix: scenarioCfg.idPrefix,
+    isDebugEnabled: scenarioCfg.isDebugEnabled,
+    delayByMotionSensors: scenarioCfg.motionSensors.delayToLightOff,
+    delayByOpeningSensors: scenarioCfg.openingSensors.delayToLightOff,
+    isDelayEnabledAfterSwitch: scenarioCfg.lightSwitches.isDelayEnabled,
+    delayBlockAfterSwitch:
+      scenarioCfg.lightSwitches.delayToLightOffAndEnable,
+    lightDevices: scenarioCfg.lightDevices.sensorObjects,
+    motionSensors: scenarioCfg.motionSensors.sensorObjects,
+    openingSensors: scenarioCfg.openingSensors.sensorObjects,
+    lightSwitches: scenarioCfg.lightSwitches.sensorObjects,
+  };
+  var isInitSuccess = scenario.init(scenarioCfg.name, cfg);
+
+  if (isInitSuccess !== true) {
+    log.error(
+      'Init operation aborted for scenario name: "{}" with idPrefix: "{}"',
+      scenarioCfg.name,
+      scenarioCfg.idPrefix
+    );
+    return;
+  }
+
+  log.debug(
+    'Initialization successful for scenario name: "{}" with idPrefix: "{}"',
+    scenarioCfg.name,
+    scenarioCfg.idPrefix
+  );
+
+  var scenarioStorage = scHelpers.getGlobalScenarioStore(
+    CFG.scenarioTypeStr
+  );
+  scenarioStorage[scenarioCfg.idPrefix] = scenario;
+  log.debug('Stored in global registry with ID: ' + scenarioCfg.idPrefix);
+}
+
+function main() {
+  log.debug('Start initialisation "{}" type scenarios', CFG.scenarioTypeStr);
+  var listAllScenarios = scHelpers.readAndValidateScenariosConfig(
+    CFG.configPath,
+    CFG.reqVerGeneralCfg
+  );
+  if (!listAllScenarios) return;
+
+  var matchedScenarios = scHelpers.findAllScenariosWithType(
+    listAllScenarios,
+    CFG.scenarioTypeStr,
+    CFG.reqVerScenario
+  );
+  if (matchedScenarios.length === 0) {
+    log.debug(
+      'No correct and active scenarios of type "{}" found',
+      CFG.scenarioTypeStr
+    );
+    return;
+  }
+
+  log.debug('Number of matched scenarios: {}', matchedScenarios.length);
+  for (var i = 0; i < matchedScenarios.length; i++) {
+    initializeScenario(matchedScenarios[i]);
+  }
+}
+
+main();

--- a/schema/wb-scenarios.schema.json
+++ b/schema/wb-scenarios.schema.json
@@ -244,7 +244,7 @@
           "title": "Config version",
           "minimum": 1,
           "maximum": 256,
-          "default": 1,
+          "default": 2,
           "options": {
             "hidden": true
           }
@@ -257,22 +257,12 @@
             "hidden": true
           }
         },
-        "enable": {
-          "title": "generalScenarioGenerateRuleTitle",
-          "type": "boolean",
-          "default": true,
-          "_format": "checkbox",
-          "propertyOrder": 1,
-          "options": {
-            "grid_columns": 12
-          }
-        },
         "isDebugEnabled": {
           "title": "generalScenarioIsDebugEnabled",
           "type": "boolean",
           "default": false,
           "_format": "checkbox",
-          "propertyOrder": 2,
+          "propertyOrder": 1,
           "options": {
             "grid_columns": 12
           }
@@ -283,12 +273,12 @@
           "default": "Управление светом",
           "minLength": 1,
           "maxLength": 120,
-          "propertyOrder": 3,
+          "propertyOrder": 2,
           "options": {
             "grid_columns": 12
           }
         },
-        "id_prefix": {
+        "idPrefix": {
           "title": "generalScenarioIdPrefixTitle",
           "type": "string",
           "description": "generalScenarioIdPrefixDescription",
@@ -297,7 +287,7 @@
           "default": "lightControl",
           "minLength": 1,
           "maxLength": 120,
-          "propertyOrder": 4,
+          "propertyOrder": 3,
           "options": {
             "grid_columns": 12,
             "patternmessage": "generalErrorRegexpPatternMessageGeneralType"
@@ -306,7 +296,7 @@
         "lightDevices": {
           "type": "object",
           "title": "lightControlLightDevicesTitle",
-          "propertyOrder": 5,
+          "propertyOrder": 4,
           "options": {
             "disable_collapse": true,
             "disable_edit_json": true,
@@ -387,7 +377,7 @@
         "lightSwitches": {
           "type": "object",
           "title": "lightControlLightSwitchesTitle",
-          "propertyOrder": 6,
+          "propertyOrder": 5,
           "options": {
             "disable_collapse": true,
             "disable_edit_json": true,
@@ -461,7 +451,7 @@
         "motionSensors": {
           "type": "object",
           "title": "lightControlMotionSensorsTitle",
-          "propertyOrder": 7,
+          "propertyOrder": 6,
           "options": {
             "disable_collapse": true,
             "disable_edit_json": true,
@@ -549,7 +539,7 @@
         "openingSensors": {
           "type": "object",
           "title": "lightControlOpeningSensorsTitle",
-          "propertyOrder": 8,
+          "propertyOrder": 7,
           "options": {
             "disable_collapse": true,
             "disable_edit_json": true,
@@ -628,9 +618,7 @@
       "required": [
         "scenarioType",
         "componentVersion",
-        "enable",
         "name",
-        "id_prefix",
         "lightDevices",
         "motionSensors",
         "openingSensors",


### PR DESCRIPTION
# Изменения

Первостепенное
1) добавил полный файл инит
По большей части это старый файл - только три изменения
- Теперь вместо простого вызова функции init() сначала создается объект сценания и потом вызывается его метод init()
- После создания и первичной инициализации - объект сценария записывается в глобальный объект чтобы не затерлось точно сборщиком мусора
- Удалена логика поиска активных сценариев, тк в конфигураторе эту функцию упразднили и удалили

2) добавил каркас файла модуля
Тут только то что дает возможность сохраненному сценарию инициализироваться
- Созданы заглушки обязательных функций
- Описан объект конфигурации
- Экспортирован класс для создания инстансов

Второстепенное
1) По схеме
- Удалил совсем свойство enable - тк его в термостате посчитали не нужным и там уже убрали
- Переименовал id_prefix в idPrefix чтобы убрать тут эту старую ошибку в конфиге
- Убрал обязательность указания idPrefix - так как он теперь по дефолту должен генерироваться транслитерацией
- Переделал с учетом удаленных полей порядок в схеме
- Изменил версию компонента с 1 на 2 тк теперь схемы могут быть не совместимы

# Зачем

Данный файл нужен чтобы далее изолировать контексты разных сценариев между собой по разным объектам

# Как проверял

Установил локально на контроллер, проверил что при создании сценария создается виртуальное устройство и его статус меняется на normal