### PR TITLE
Hide scenario in configs list

### DIFF
--- a/schema/wb-scenarios.schema.json
+++ b/schema/wb-scenarios.schema.json
@@ -4,7 +4,8 @@
   "title": "Automation scenarios",
   "configFile": {
     "path": "/etc/wb-scenarios.conf",
-    "service": "wb-scenarios-reloader"
+    "service": "wb-scenarios-reloader",
+    "hide":true
   },
   "options": {
     "wb": {


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Скрывает конфигуратор сценариев из "Settings-configs"
Доступ к сценариям теперь в "Rule-Scenarios"(Добавлено в [тут](https://github.com/wirenboard/homeui/pull/783))

___________________________________
**Что поменялось для пользователей:**
Было 
<img width="851" height="697" alt="image" src="https://github.com/user-attachments/assets/5f1112e6-154c-44b3-9cbd-60177d3f0305" />

Стало
<img width="1103" height="602" alt="image" src="https://github.com/user-attachments/assets/3a6a89ff-b339-422a-a2d3-bcd752eae2bc" />


___________________________________
**Как проверял/а:**


