### PR TITLE
fix: increase wait controls timeout to 60s and actualize thermostat

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-scenarios (1.6.0) stable; urgency=medium
+
+  * fix: increase wait controls timeout to 60s and actualize thermostat
+
+ -- Vitalii Gaponov <vitalii.gaponov@wirenboard.com>  Wed, 06 Aug 2025 12:00:00 +0300
+
 wb-scenarios (1.5.0) stable; urgency=medium
 
   * hide scenarios in configs list

--- a/scenarios/devices-control/README.md
+++ b/scenarios/devices-control/README.md
@@ -9,25 +9,25 @@
 
 Конфигурация выглядит следующим образом
 
-![alt text](doc/scenario-config.png)
+![Scenario config](doc/scenario-config.png)
 
 Каждому сценарию создается виртуальное устройство
 
-![virtual-device](doc/virtual-device.png)
+![Virtual device](doc/virtual-device.png)
 
 ## Использование модуля
 
 Вы можете использовать модуль управления устройствами прямо из своих
 правил `wb-rules`.
 
-Для этого нужно сделать 3 шага:
+Для этого нужно сделать 4 шага:
 
-1) Подключить модуль в коде скрипта
-2) Создать объект конфигурации
-   В этом объекте нужно прописать
+1) Импортировать класс кастомного сценария
+2) Создать новый инстанс класса "управление устройствами"
+3) Создать объект настроек где прописать что вы хотите использовать:
    - Настройки входних контролов
    - Настройки выходных контролов
-3) Инициализировать алгоритм указав:
+4) Инициализировать алгоритм указав:
    - Имя виртуального устройства
    - Созданный объект конфигурации
 
@@ -121,20 +121,17 @@ DevicesControlConfig:
  * @file: devices-control-example.js
  */
 
-// Step 1: import devices control module
+// Step 1: import module
 var CustomTypeSc = require('devices-control.mod').DevicesControlScenario;
 
 function main() {
-  log.debug('Start init logic for: Master switch');
+  scenarioName = 'Master switch';
+  log.debug('Start init logic for: "{}"', scenarioName);
 
   // Step 2: Create new instance with scenario class
   var scenario = new CustomTypeSc();
 
-
-function main() {
-  log.debug('Start init logic for: Master switch');
-
-  // Step 3: Configure algorithm for input+output linking
+  // Step 3: Configure algorithm
   var cfg = {
     idPrefix: 'master_switch',
     inControls: [
@@ -158,21 +155,21 @@ function main() {
   };
 
 
-  // Step 4: init devices-control algorithm
+  // Step 4: init algorithm
   try {
-    var isInitSuccess = scenario.init('Master switch', cfg);
+    var isInitSuccess = scenario.init(scenarioName, cfg);
     
     if (!isInitSuccess) {
-      log.error('Init operation aborted for scenario: "Master switch"');
+      log.error('Init operation aborted for scenario: "{}"', scenarioName);
       return;
     }
 
-    log.debug('Initialization successful for: Master switch');
+    log.debug('Initialization successful for: "{}"', scenarioName);
   } catch (error) {
     log.error(
       'Exception during scenario initialization: "{}" for scenario: "{}"', 
       error.message || error, 
-      'Master switch'
+      scenarioName
     );
   }
 }

--- a/scenarios/devices-control/devices-control.mod.js
+++ b/scenarios/devices-control/devices-control.mod.js
@@ -13,10 +13,11 @@
  */
 
 var ScenarioBase = require('wbsc-scenario-base.mod').ScenarioBase;
-var ScenarioState = require('wbsc-scenario-base.mod').ScenarioState;
+var ScenarioState = require('virtual-device-helpers.mod').ScenarioState;
+var Logger = require('logger.mod').Logger;
+
 var eTable = require("table-handling-events.mod");
 var aTable = require("table-handling-actions.mod");
-var Logger = require('logger.mod').Logger;
 
 var loggerFileLabel = 'WBSC-input-output-link-mod';
 var log = new Logger(loggerFileLabel);
@@ -60,17 +61,17 @@ DevicesControlScenario.prototype.constructor = DevicesControlScenario;
  */
 DevicesControlScenario.prototype.generateNames = function(idPrefix) {
   var scenarioPrefix = 'wbsc_';
-  var rulePrefix = 'wbru_';
+  var baseRuleName = scenarioPrefix + idPrefix + '_';
   
   return {
     vDevice: scenarioPrefix + idPrefix,
-    ruleMain: rulePrefix + idPrefix
+    ruleMain: baseRuleName + 'mainRule',
   };
 };
 
 /**
  * Get configuration for waiting for controls
- * @param {Object} cfg Configuration object
+ * @param {Object} cfg - Configuration object
  * @returns {Object} Waiting configuration object
  */
 DevicesControlScenario.prototype.defineControlsWaitConfig = function (cfg) {

--- a/scenarios/devices-control/scenario-init-devices-control.mod.js
+++ b/scenarios/devices-control/scenario-init-devices-control.mod.js
@@ -47,7 +47,7 @@ function initializeScenario(scenarioCfg) {
       log.error(
         'Init operation aborted for scenario name: "{}" with idPrefix: "{}"',
         scenarioCfg.name,
-        scenarioCfg.id_prefix
+        scenario.idPrefix
       );
       return;
     }
@@ -55,14 +55,14 @@ function initializeScenario(scenarioCfg) {
     log.debug(
       'Initialization successful for scenario name: "{}" with idPrefix: "{}"',
       scenarioCfg.name,
-      scenarioCfg.id_prefix
+      scenario.idPrefix
     );
 
     var scenarioStorage = scHelpers.getGlobalScenarioStore(
       CFG.scenarioTypeStr
     );
-    scenarioStorage[scenarioCfg.id_prefix] = scenario;
-    log.debug('Stored in global registry with ID: {}', scenarioCfg.id_prefix);
+    scenarioStorage[scenario.idPrefix] = scenario;
+    log.debug('Stored in global registry with ID: {}', scenario.idPrefix);
   } catch (error) {
     log.error(
       'Exception during scenario initialization: "{}" for scenario: "{}"', 

--- a/scenarios/devices-control/scenario-init-devices-control.mod.js
+++ b/scenarios/devices-control/scenario-init-devices-control.mod.js
@@ -41,11 +41,11 @@ function initializeScenario(scenarioCfg) {
   };
 
   try {
-    var isInitSuccess = scenario.init(scenarioCfg.name, cfg);
-
-    if (isInitSuccess !== true) {
+    // Returns true if VD created successfully; full initialization continue asynchronously
+    var isVirtualDeviceCreated = scenario.init(scenarioCfg.name, cfg);
+    if (isVirtualDeviceCreated !== true) {
       log.error(
-        'Init operation aborted for scenario name: "{}" with idPrefix: "{}"',
+        'Virtual device creation failed for scenario name: "{}" with idPrefix: "{}"',
         scenarioCfg.name,
         scenario.idPrefix
       );
@@ -53,7 +53,7 @@ function initializeScenario(scenarioCfg) {
     }
 
     log.debug(
-      'Initialization successful for scenario name: "{}" with idPrefix: "{}"',
+      'VD created successfully, init continue asynchronously for scenario name: "{}" with idPrefix: "{}"',
       scenarioCfg.name,
       scenario.idPrefix
     );

--- a/scenarios/devices-control/scenario-init-devices-control.mod.js
+++ b/scenarios/devices-control/scenario-init-devices-control.mod.js
@@ -42,8 +42,8 @@ function initializeScenario(scenarioCfg) {
 
   try {
     // Returns true if VD created successfully; full initialization continue asynchronously
-    var isVirtualDeviceCreated = scenario.init(scenarioCfg.name, cfg);
-    if (isVirtualDeviceCreated !== true) {
+    var isBasicVdCreated = scenario.init(scenarioCfg.name, cfg);
+    if (isBasicVdCreated !== true) {
       log.error(
         'Virtual device creation failed for scenario name: "{}" with idPrefix: "{}"',
         scenarioCfg.name,

--- a/scenarios/light-control/README.md
+++ b/scenarios/light-control/README.md
@@ -65,31 +65,34 @@
 
 ## Использование модуля
 
-Вы можете использовать функционал управления светом из своих правил wb-rules
-Для этого нужно сделать 3 шага:
+Вы можете использовать модуль управления светом прямо из своих
+правил `wb-rules`. Для этого нужно сделать 4 шага:
 
-1) Импортировать класс кастомного сценария управления светом
-2) Создать новый инстанс класса управления светом
+1) Импортировать класс кастомного сценария
+2) Создать новый инстанс класса "управление светом"
 3) Создать объект настроек где прописать что вы хотите использовать
-4) Инициализировать алгоритм указав
+4) Инициализировать алгоритм указав:
    - Имя виртуального устройства
    - Созданный объект конфигурации
 
+### Пример кода
+
 ```js
 /**
- * @file: light_init.js
+ * @file: light-init.js
  */
 
-// Step 1: import light module
+// Step 1: import module
 var CustomTypeSc = require('light-control.mod').LightControlScenario;
 
 function main() {
-  log.debug('Start init logic for: Bathroom light');
+  scenarioName = 'Bathroom light';
+  log.debug('Start init logic for: "{}"', scenarioName);
 
   // Step 2: Create new instance with scenario class
   var scenario = new CustomTypeSc();
 
-  // Step 3: Configure algorithm for light
+  // Step 3: Configure algorithm
   var cfg = {
     idPrefix: 'bathroom_light',
     isDebugEnabled: false,
@@ -135,21 +138,21 @@ function main() {
   };
 
   
-  // Step 4: init light algorithm
+  // Step 4: init algorithm
   try {
-    var isInitSuccess = scenario.init('Bathroom light', cfg);
+    var isInitSuccess = scenario.init(scenarioName, cfg);
 
     if (!isInitSuccess) {
-      log.error('Init operation aborted for scenario: "Bathroom light"');
+      log.error('Init operation aborted for scenario: "{}"', scenarioName);
       return;
     }
 
-    log.debug('Initialization successful for: Bathroom light');
+    log.debug('Initialization successful for: "{}"', scenarioName);
   } catch (error) {
     log.error(
       'Exception during scenario initialization: "{}" for scenario: "{}"', 
       error.message || error, 
-      scenarioCfg.name
+      scenarioName
     );
   }
 }

--- a/scenarios/light-control/scenario-init-light-control.mod.js
+++ b/scenarios/light-control/scenario-init-light-control.mod.js
@@ -55,7 +55,7 @@ function initializeScenario(scenarioCfg) {
       log.error(
         'Init operation aborted for scenario name: "{}" with idPrefix: "{}"',
         scenarioCfg.name,
-        scenarioCfg.id_prefix
+        scenario.idPrefix
       );
       return;
     }
@@ -63,14 +63,14 @@ function initializeScenario(scenarioCfg) {
     log.debug(
       'Initialization successful for scenario name: "{}" with idPrefix: "{}"',
       scenarioCfg.name,
-      scenarioCfg.id_prefix
+      scenario.idPrefix
     );
 
     var scenarioStorage = scHelpers.getGlobalScenarioStore(
       CFG.scenarioTypeStr
     );
-    scenarioStorage[scenarioCfg.id_prefix] = scenario;
-    log.debug('Stored in global registry with ID: ' + scenarioCfg.id_prefix);
+    scenarioStorage[scenario.idPrefix] = scenario;
+    log.debug('Stored in global registry with ID: ' + scenario.idPrefix);
   } catch (error) {
     log.error(
       'Exception during scenario initialization: "{}" for scenario: "{}"', 

--- a/scenarios/light-control/scenario-init-light-control.mod.js
+++ b/scenarios/light-control/scenario-init-light-control.mod.js
@@ -50,8 +50,8 @@ function initializeScenario(scenarioCfg) {
 
   try {
     // Returns true if VD created successfully; full initialization continue asynchronously
-    var isVirtualDeviceCreated = scenario.init(scenarioCfg.name, cfg);
-    if (isVirtualDeviceCreated !== true) {
+    var isBasicVdCreated = scenario.init(scenarioCfg.name, cfg);
+    if (isBasicVdCreated !== true) {
       log.error(
         'Virtual device creation failed for scenario name: "{}" with idPrefix: "{}"',
         scenarioCfg.name,

--- a/scenarios/light-control/scenario-init-light-control.mod.js
+++ b/scenarios/light-control/scenario-init-light-control.mod.js
@@ -49,11 +49,11 @@ function initializeScenario(scenarioCfg) {
   };
 
   try {
-    var isInitSuccess = scenario.init(scenarioCfg.name, cfg);
-
-    if (isInitSuccess !== true) {
+    // Returns true if VD created successfully; full initialization continue asynchronously
+    var isVirtualDeviceCreated = scenario.init(scenarioCfg.name, cfg);
+    if (isVirtualDeviceCreated !== true) {
       log.error(
-        'Init operation aborted for scenario name: "{}" with idPrefix: "{}"',
+        'Virtual device creation failed for scenario name: "{}" with idPrefix: "{}"',
         scenarioCfg.name,
         scenario.idPrefix
       );
@@ -61,7 +61,7 @@ function initializeScenario(scenarioCfg) {
     }
 
     log.debug(
-      'Initialization successful for scenario name: "{}" with idPrefix: "{}"',
+      'VD created successfully, init continue asynchronously for scenario name: "{}" with idPrefix: "{}"',
       scenarioCfg.name,
       scenario.idPrefix
     );

--- a/scenarios/thermostat/README.md
+++ b/scenarios/thermostat/README.md
@@ -113,17 +113,15 @@
 
 ## Использование модуля
 
-Вы можете использовать модуль термостата для управления нагревом прямо
-из своих правил `wb-rules`.
+Вы можете использовать модуль термостата прямо из своих
+правил `wb-rules`. Для этого нужно сделать 4 шага:
 
-Для этого нужно сделать 3 шага:
-
-1) Подключить модуль в коде скрипта
-2) Создать объект конфигурации
-   В этом объекте нужно прописать
+1) Импортировать класс кастомного сценария
+2) Создать новый инстанс класса "термостат"
+3) Создать объект настроек где прописать что вы хотите использовать:
    - общие настройки целевой температуры и тд
    - топики которые вы хотите использовать для датчика и нагревателя
-3) Инициализировать алгоритм указав:
+4) Инициализировать алгоритм указав:
    - Имя виртуального устройства
    - Созданный объект конфигурации
 
@@ -158,13 +156,17 @@ ThermostatConfig:
  * @file: init-heating.js
  */
 
-// Step 1: include module
-var scenarioModule = require('thermostat.mod');
+// Step 1: import module
+var CustomTypeSc = require('thermostat.mod').ThermostatScenario;
 
 function main() {
-  log.debug('Start init logic for: Bathroom light');
+  var scenarioName = 'Bathroom: heat floor';
+  log.debug('Start init logic for: "{}"', scenarioName);
 
-  // Step 2: Configure algorithm
+  // Step 2: Create new instance with scenario class
+  var scenario = new CustomTypeSc();
+
+  // Step 3: Configure algorithm
   var cfg = {
     idPrefix: 'bathroom_floor',// Не обязательный параметр, можно не указывать
     targetTemp: 22,
@@ -175,14 +177,23 @@ function main() {
     actuator: 'wb-mr6cv3_127/K6',
   };
 
-  // Step 3: init algorithm
-  var isInitSuccess = scenarioModule.init('Bathroom: heat floor', cfg);
-  if (!isInitSuccess) {
-    log.error('Error: Init aborted for "idPrefix": {}', cfg.idPrefix);
-    return;
-  }
+  // Step 4: init algorithm
+  try {
+    var isInitSuccess = scenario.init(scenarioName, cfg);
 
-  log.debug('Initialization successful for "idPrefix": {}', cfg.idPrefix);
+    if (!isInitSuccess) {
+      log.error('Init operation aborted for scenario: "{}"', scenarioName);
+      return;
+    }
+
+    log.debug('Initialization successful for: "{}"', scenarioName);
+  } catch (error) {
+    log.error(
+      'Exception during scenario initialization: "{}" for scenario: "{}"', 
+      error.message || error, 
+      scenarioName
+    );
+  }
 }
 
 main();

--- a/scenarios/thermostat/scenario-init-thermostat.mod.js
+++ b/scenarios/thermostat/scenario-init-thermostat.mod.js
@@ -45,11 +45,11 @@ function initializeScenario(scenarioCfg) {
   };
 
   try {
-    var isInitSuccess = scenario.init(scenarioCfg.name, cfg);
-
-    if (isInitSuccess !== true) {
+    // Returns true if VD created successfully; full initialization continue asynchronously
+    var isVirtualDeviceCreated = scenario.init(scenarioCfg.name, cfg);
+    if (isVirtualDeviceCreated !== true) {
       log.error(
-        'Init operation aborted for scenario name: "{}" with idPrefix: "{}"',
+        'Virtual device creation failed for scenario name: "{}" with idPrefix: "{}"',
         scenarioCfg.name,
         scenario.idPrefix
       );
@@ -57,7 +57,7 @@ function initializeScenario(scenarioCfg) {
     }
 
     log.debug(
-      'Initialization successful for scenario name: "{}" with idPrefix: "{}"',
+      'VD created successfully, init continue asynchronously for scenario name: "{}" with idPrefix: "{}"',
       scenarioCfg.name,
       scenario.idPrefix
     );

--- a/scenarios/thermostat/scenario-init-thermostat.mod.js
+++ b/scenarios/thermostat/scenario-init-thermostat.mod.js
@@ -51,7 +51,7 @@ function initializeScenario(scenarioCfg) {
       log.error(
         'Init operation aborted for scenario name: "{}" with idPrefix: "{}"',
         scenarioCfg.name,
-        scenarioCfg.idPrefix
+        scenario.idPrefix
       );
       return;
     }
@@ -59,14 +59,14 @@ function initializeScenario(scenarioCfg) {
     log.debug(
       'Initialization successful for scenario name: "{}" with idPrefix: "{}"',
       scenarioCfg.name,
-      scenarioCfg.idPrefix
+      scenario.idPrefix
     );
 
     var scenarioStorage = scHelpers.getGlobalScenarioStore(
       CFG.scenarioTypeStr
     );
-    scenarioStorage[scenarioCfg.idPrefix] = scenario;
-    log.debug('Stored in global registry with ID: ' + scenarioCfg.idPrefix);
+    scenarioStorage[scenario.idPrefix] = scenario;
+    log.debug('Stored in global registry with ID: ' + scenario.idPrefix);
   } catch (error) {
     log.error(
       'Exception during scenario initialization: "{}" for scenario: "{}"', 

--- a/scenarios/thermostat/scenario-init-thermostat.mod.js
+++ b/scenarios/thermostat/scenario-init-thermostat.mod.js
@@ -46,8 +46,8 @@ function initializeScenario(scenarioCfg) {
 
   try {
     // Returns true if VD created successfully; full initialization continue asynchronously
-    var isVirtualDeviceCreated = scenario.init(scenarioCfg.name, cfg);
-    if (isVirtualDeviceCreated !== true) {
+    var isBasicVdCreated = scenario.init(scenarioCfg.name, cfg);
+    if (isBasicVdCreated !== true) {
       log.error(
         'Virtual device creation failed for scenario name: "{}" with idPrefix: "{}"',
         scenarioCfg.name,

--- a/scenarios/thermostat/thermostat.mod.js
+++ b/scenarios/thermostat/thermostat.mod.js
@@ -1,34 +1,69 @@
 /**
- * @file thermostat.mod.js - module for WirenBoard wb-rules 2.0
- * @description Module for initializing the thermostat algorithm
- *     based on user-specified parameters
+ * @file thermostat.mod.js - ES5 module for wb-rules v2.34
+ * @description Thermostat scenario class that extends ScenarioBase
  *
  * @author Vitalii Gaponov <vitalii.gaponov@wirenboard.com>
- * @link Comments formatted in JSDoc <https://jsdoc.app/> - Google styleguide
  */
 
-var helpers = require('scenarios-general-helpers.mod');
+var ScenarioBase = require('wbsc-scenario-base.mod').ScenarioBase;
+var ScenarioState = require('virtual-device-helpers.mod').ScenarioState;
 var Logger = require('logger.mod').Logger;
-var createBasicVd = require('virtual-device-helpers.mod').createBasicVd;
-var setVdTotalError = require('virtual-device-helpers.mod').setVdTotalError;
+
+var hasCriticalErr = require('wbsc-wait-controls.mod').hasCriticalErr;
 
 var loggerFileLabel = 'WBSC-thermostat-mod';
 var log = new Logger(loggerFileLabel);
 
 /**
- * One persistent-storage for all scenarios this type
- * @example
- *   ps = {
- *     "bathroom_floor": {
- *       "targetTemp": 22
- *     },
- *     "kitchen_heater": {
- *       "targetTemp": 24
- *     },
- *     ...
- *   }
+ * @typedef {Object} ThermostatConfig
+ * @property {string} [idPrefix] - Optional prefix for scenario identification
+ *   If not provided, it will be generated from the scenario name
+ * @property {number} targetTemp - Target temperature set by the user
+ * @property {number} hysteresis - Hysteresis value (switching range)
+ * @property {number} tempLimitsMin - Lower limit for temperature setting
+ * @property {number} tempLimitsMax - Upper limit for temperature setting
+ * @property {string} tempSensor - Name of the input control topic - monitored
+ *   Example: temperature sensor whose value should be tracked
+ *   'temp_sensor/temp_value'
+ * @property {string} actuator - Name of the output control topic - controlled
+ *   Example: relay output to be controlled - 'relay_module/K2'
  */
-var ps = null;
+
+/**
+ * Thermostat control scenario implementation
+ * @class ThermostatScenario
+ * @extends ScenarioBase
+ */
+function ThermostatScenario() {
+  ScenarioBase.call(this);
+
+  /**
+   * Context object for storing scenario runtime state
+   * @type {Object}
+   */
+  this.ctx = {
+    /**
+     * One persistent-storage for all scenarios this type
+     * contain target temperature set by user in virtual device
+     * @example
+     *   ps = {
+     *     "bathroom_floor": {
+     *       "targetTemp": 22
+     *     },
+     *     "kitchen_heater": {
+     *       "targetTemp": 24
+     *     },
+     *     ...
+     *   }
+     */
+    ps: null,
+    
+    errorTimers: {}, // Timers for error handling debounce
+    errorCheckTimeoutMs: 10000 // 10s debounce time for errors
+  };
+}
+ThermostatScenario.prototype = Object.create(ScenarioBase.prototype);
+ThermostatScenario.prototype.constructor = ThermostatScenario;
 
 /**
  * Control key strings for virtual device
@@ -42,57 +77,47 @@ var vdCtrl = {
 };
 
 /**
- * Generates the names to be used
- * @param {string} idPrefix Prefix for identifying this algorithm
- *     For example: 'warm_floor_in_bathroom'
- * @returns {Object} An object with generated names
+ * Generates name identifiers for virtual device and rules
+ * @param {string} idPrefix - ID prefix for this scenario instance
+ * @returns {Object} Generated names
  */
-function generateNames(idPrefix) {
+ThermostatScenario.prototype.generateNames = function (idPrefix) {
   var scenarioPrefix = 'wbsc_';
-  var baseRuleName = scenarioPrefix + idPrefix;
+  var baseRuleName = scenarioPrefix + idPrefix + '_';
 
-  var generatedNames = {
+  return {
     vDevice: scenarioPrefix + idPrefix,
-    ruleSyncActStatus: baseRuleName + '_sync_act_status',
-    ruleTempChanged: baseRuleName + '_temp_changed',
-    ruleSetScStatus: baseRuleName + '_set_sc_status',
-    ruleSetTargetTemp: baseRuleName + '_set_target_t',
-    ruleSensorErr: baseRuleName + '_sensor_error_changed',
-    ruleActuatorErr: baseRuleName + '_actuator_error_changed',
+    ruleTempChanged: baseRuleName + 'temp_changed',
+    ruleSyncActStatus: baseRuleName + 'sync_act_status',
+    ruleSetScStatus: baseRuleName + 'set_sc_status',
+    ruleSetTargetTemp: baseRuleName + 'set_target_t',
+    ruleSensorErr: baseRuleName + 'sensor_error_changed',
+    ruleActuatorErr: baseRuleName + 'actuator_error_changed',
   };
-
-  return generatedNames;
-}
+};
 
 /**
- * @typedef {Object} ThermostatConfig
- * @property {string} [idPrefix] Optional prefix for the name to identify
- *     the virtual device and rule:
- *     - If specified, the virtual device and rule will be named
- *       `wbsc_<!idPrefix!>` and `wbru_<!idPrefix!>`
- *     - If not specified (undefined), the name will be generated
- *       by transliterating the name passed to `init()`
- * @property {number} targetTemp Target temperature set by the user
- * @property {number} hysteresis Hysteresis value (switching range)
- * @property {number} tempLimitsMin Lower limit for temperature setting
- * @property {number} tempLimitsMax Upper limit for temperature setting
- * @property {string} tempSensor Name of the input control topic - monitored
- *     Example: temperature sensor whose value should be tracked
- *     'temp_sensor/temp_value'
- * @property {string} actuator Name of the output control topic - controlled
- *     Example: relay output to be controlled - 'relay_module/K2'
+ * Get configuration for waiting for controls
+ * @param {Object} cfg - Configuration object
+ * @returns {Object} Waiting configuration object
  */
+ThermostatScenario.prototype.defineControlsWaitConfig = function (cfg) {
+  var allTopics = [].concat(
+    cfg.tempSensor,
+    cfg.actuator
+  );
+
+  return { controls: allTopics };
+};
 
 /**
- * Validate the configuration parameters
- * @param {ThermostatConfig} cfg Configuration parameters
- * @returns {boolean} Validation status:
- *     - true: if the parameters are valid
- *     - false: if there is an error
+ * Configuration validation
+ * @param {ThermostatConfig} cfg - Configuration object
+ * @returns {boolean} True if configuration is valid, false otherwise
  */
-function isConfigValid(cfg) {
+ThermostatScenario.prototype.validateCfg = function (cfg) {
   var isLimitsCorrect = cfg.tempLimitsMin <= cfg.tempLimitsMax;
-  if (isLimitsCorrect !== true) {
+  if (!isLimitsCorrect) {
     log.error(
       'Config temperature limit "Min" = "{}" must be less than "Max" = "{}"',
       cfg.tempLimitsMin,
@@ -103,7 +128,7 @@ function isConfigValid(cfg) {
   var isTargetTempCorrect =
     cfg.targetTemp >= cfg.tempLimitsMin &&
     cfg.targetTemp <= cfg.tempLimitsMax;
-  if (isTargetTempCorrect !== true) {
+  if (!isTargetTempCorrect) {
     log.error(
       'Target temperature "{}" must be in the range from "Min" to "Max"',
       cfg.targetTemp
@@ -111,7 +136,7 @@ function isConfigValid(cfg) {
   }
 
   var isHysteresisCorrect = cfg.hysteresis > 0;
-  if (isHysteresisCorrect !== true) {
+  if (!isHysteresisCorrect) {
     log.error(
       'Hysteresis value must be greater than 0, but got "{}"',
       cfg.hysteresis
@@ -123,7 +148,7 @@ function isConfigValid(cfg) {
     tempSensorType === null ||
     tempSensorType === 'value' ||
     tempSensorType === 'temperature';
-  if (isTempSensorValid !== true) {
+  if (!isTempSensorValid) {
     log.error(
       'Sensor type must be "value" or "temperature", but got "{}"',
       tempSensorType
@@ -132,7 +157,7 @@ function isConfigValid(cfg) {
 
   var actuatorType = dev[cfg.actuator + '#type'];
   var isActuatorValid = actuatorType === null || actuatorType === 'switch';
-  if (isActuatorValid !== true) {
+  if (!isActuatorValid) {
     log.error('Actuator type must be "switch", but got "{}"', actuatorType);
   }
 
@@ -144,15 +169,15 @@ function isConfigValid(cfg) {
     isActuatorValid;
 
   return isCfgValid;
-}
+};
 
 /**
- * Adds custom control cells to a virtual device for scenario functionality
- * @param {Object} vdObj The virtual device object
- * @param {ThermostatConfig} cfg Configuration parameters
- * @param {number} initialTemp Initial value for the target temperature
+ * Adds required custom controls cells to the virtual device
+ * @param {Object} self - Reference to the ThermostatScenario instance
+ * @param {ThermostatConfig} cfg - Configuration object
+ * @param {number} initialTemp - Initial value for the target temperature
  */
-function addCustomCellsToVd(vdObj, cfg, initialTemp) {
+function addCustomControlsToVirtualDevice(self, cfg, initialTemp) {
   var controlCfg = {
     title: {
       en: 'Temperature Setpoint',
@@ -164,7 +189,7 @@ function addCustomCellsToVd(vdObj, cfg, initialTemp) {
     max: cfg.tempLimitsMax,
     order: 2,
   };
-  vdObj.addControl(vdCtrl.targetTemp, controlCfg);
+  self.vd.devObj.addControl(vdCtrl.targetTemp, controlCfg);
 
   controlCfg = {
     title: {
@@ -177,7 +202,7 @@ function addCustomCellsToVd(vdObj, cfg, initialTemp) {
     order: 3,
     readonly: true,
   };
-  vdObj.addControl(vdCtrl.curTemp, controlCfg);
+  self.vd.devObj.addControl(vdCtrl.curTemp, controlCfg);
 
   controlCfg = {
     title: {
@@ -189,14 +214,14 @@ function addCustomCellsToVd(vdObj, cfg, initialTemp) {
     order: 4,
     readonly: true,
   };
-  vdObj.addControl(vdCtrl.actuatorStatus, controlCfg);
+  self.vd.devObj.addControl(vdCtrl.actuatorStatus, controlCfg);
 }
 
 /**
  * @typedef {Object} HeatingStateData
- * @property {number} curTemp The current temperature (°C)
- * @property {number} targetTemp The target temperature (°C)
- * @property {number} hysteresis The hysteresis value (°C)
+ * @property {number} curTemp - The current temperature (°C)
+ * @property {number} targetTemp - The target temperature (°C)
+ * @property {number} hysteresis - The hysteresis value (°C)
  *
  * @example
  * var data = {
@@ -209,8 +234,8 @@ function addCustomCellsToVd(vdObj, cfg, initialTemp) {
 /**
  * Updates the heating state based on current temperature, target
  * temperature, and hysteresis. Sets the new state if it has changed
- * @param {string} actuator The actuator identifier (key in the dev object)
- * @param {HeatingStateData} data Heating state data
+ * @param {string} actuator - The actuator identifier (key in the dev object)
+ * @param {HeatingStateData} data - Heating state data
  */
 function updateHeatingState(actuator, data) {
   var currentState = dev[actuator];
@@ -241,69 +266,33 @@ function updateHeatingState(actuator, data) {
 }
 
 /**
- * Checks if the given error value contains a critical error.
- * A critical error is defined as a string containing 'r' or 'w'
- * @param {string|undefined} errorVal The error value to check
- * @returns {boolean} True if there is a critical error, false otherwise
- */
-function hasCriticalErr(errorVal) {
-  if (typeof errorVal !== 'string') {
-    return false;
-  }
-
-  return (errorVal.indexOf('r') !== -1 || errorVal.indexOf('w') !== -1);
-}
-
-/**
- * Checks if all specified topics are properly initialized
- * 
- * @param {string[]} topics - Array of string topics to check
- *     Example: ['relay_module/K2', 'temp_sensor/temp_value']
- * @returns {boolean} Returns true if ALL topics in the array are initialized
- *     (non-null #type) and have no critical errors, otherwise false
- */
-function areControlsInited(topics) {
-  for (var i = 0; i < topics.length; i++) {
-    var topic = topics[i];
-    if (dev[topic + '#type'] === null) {
-      return false;
-    }
-    if (hasCriticalErr(dev[topic + '#error'])) {
-      return false;
-    }
-  }
-  return true;
-}
-
-/**
  * Updates the readonly state of the rule enable control
  * Removes readonly only when both errors (sensor and actuator) are cleared
- * @param {object} vdCtrlEnable Control "Enable rules" in scenario virtual dev
- * @param {ThermostatConfig} cfg Configuration parameters
+ * @param {Object} vdCtrlEnable - Control "Enable rules" in scenario virtual dev
+ * @param {ThermostatConfig} cfg - Configuration parameters
  */
 function tryClearReadonly(vdCtrlEnable, cfg) {
-  if ( !hasCriticalErr(dev[cfg.tempSensor + '#error']) &&
+  if (!hasCriticalErr(dev[cfg.tempSensor + '#error']) &&
        !hasCriticalErr(dev[cfg.actuator + '#error'])
   ) {
     vdCtrlEnable.setReadonly(false);
   }
 }
 
-var errorTimers = {};
-var errorCheckTimeoutMs = 10000; // 10s debounce time
-
 /**
  * Creates an error handling rule for a sensor or actuator
- * @param {string} ruleName The name of the rule to be created
- * @param {string} sourceErrTopic The MQTT topic where error events published
+ * @param {Object} self - Reference to the ThermostatScenario instance
+ * @param {string} ruleName - The name of the rule to be created
+ * @param {string} sourceErrTopic - The MQTT topic where error events published
  *     Example: "temperature_sensor/temperature#error", "relay_module/K2#error"
- * @param {Object} targetVdCtrl The target virtual device control for sync
+ * @param {Object} targetVdCtrl - The target virtual device control for sync
  *     Example: `vdCtrlCurTemp = vdObj.getControl('ctrlID')`
- * @param {object} vdCtrlEnable Control "Enable rules" in scenario virtual dev
- * @param {ThermostatConfig} cfg Configuration parameters
- * @returns {number|null} The ID of the created rule, or `null` if failed
+ * @param {Object} vdCtrlEnable - Control "Enable rules" in scenario virtual dev
+ * @param {ThermostatConfig} cfg - Configuration parameters
+ * @returns {boolean} True if rule created successfully
  */
 function createErrChangeRule(
+  self,
   ruleName,
   sourceErrTopic,
   targetVdCtrl,
@@ -322,11 +311,12 @@ function createErrChangeRule(
           newValue
         );
         tryClearReadonly(vdCtrlEnable, cfg);
+        self.setState(ScenarioState.NORMAL);
 
         // If on this topic was running timer - disable this timer
-        if (errorTimers[sourceErrTopic]) {
-          clearTimeout(errorTimers[sourceErrTopic]);
-          errorTimers[sourceErrTopic] = null;
+        if (self.ctx.errorTimers[sourceErrTopic]) {
+          clearTimeout(self.ctx.errorTimers[sourceErrTopic]);
+          self.ctx.errorTimers[sourceErrTopic] = null;
           log.debug(
             'Debounce timer for error for topic "{}" disabled',
             sourceErrTopic
@@ -342,20 +332,21 @@ function createErrChangeRule(
       );
 
       // Create new timer only if not have running already
-      if (errorTimers[sourceErrTopic]) {
+      if (self.ctx.errorTimers[sourceErrTopic]) {
         return;
       }
 
-      errorTimers[sourceErrTopic] = setTimeout(function () {
+      self.ctx.errorTimers[sourceErrTopic] = setTimeout(function () {
         // When timer stop - check still critical errors r/w
         var currentErrorVal = dev[sourceErrTopic];
         if (hasCriticalErr(currentErrorVal)) {
           log.error(
             'Scenario disabled: critical error (r/w) for topic "{}" not cleared for {} ms. Current error state: "{}"',
             sourceErrTopic,
-            errorCheckTimeoutMs,
+            self.ctx.errorCheckTimeoutMs,
             currentErrorVal
           );
+          self.setState(ScenarioState.USED_CONTROL_ERROR);
           vdCtrlEnable.setReadonly(true);
           vdCtrlEnable.setValue(false);
         } else {
@@ -364,8 +355,8 @@ function createErrChangeRule(
             sourceErrTopic
           );
         }
-        errorTimers[sourceErrTopic] = null;
-      }, errorCheckTimeoutMs);
+        self.ctx.errorTimers[sourceErrTopic] = null;
+      }, self.ctx.errorCheckTimeoutMs);
     },
   };
 
@@ -374,22 +365,74 @@ function createErrChangeRule(
 }
 
 /**
- * Creates thermostat control rules
- * @param {ThermostatConfig} cfg Configuration parameters
- * @param {Object} genNames Generated names
- * @param {Object} vdObj Scenario virtual device
- * @param {Array<string>} managedRulesId Array of rule IDs for enabling/disabling
- * @param {string} idPrefix Unique identifier of the scenario for persistent storage
+ * Restore target temperature from persistent storage (if saved previosly)
+ * If the stored value is invalid or missing, we use cfg.targetTemp and save it
+ * @param {Object} self - Reference to the ThermostatScenario instance
+ * @param {ThermostatConfig} cfg - Thermostat config
+ * @returns {number} The target temperature to use
  */
-function createRules(cfg, genNames, vdObj, managedRulesId, idPrefix) {
-  var vdCtrlCurTemp = vdObj.getControl(vdCtrl.curTemp);
-  var vdCtrlActuator = vdObj.getControl(vdCtrl.actuatorStatus);
-  var vdCtrlTargetTemp = vdObj.getControl(vdCtrl.targetTemp);
-  var vdCtrlEnable = vdObj.getControl(vdCtrl.ruleEnabled);
+function restoreTargetTemperature(self, cfg) {
+  if (typeof self.ctx.ps[self.idPrefix] === 'undefined') {
+    try {
+      self.ctx.ps[self.idPrefix] = StorableObject({});
+    } catch (err) {
+      log.error('Error on self.ctx.ps[self.idPrefix] assignment: {}', err);
+      return cfg.targetTemp;
+    }
+
+    log.debug(
+      'Created new record in persistent storage for scenario="{}"',
+      self.idPrefix
+    );
+  }
+
+  var storedTemp = self.ctx.ps[self.idPrefix].targetTemp;
+  var isValidStoredTemp =
+    typeof storedTemp === 'number' &&
+    storedTemp >= cfg.tempLimitsMin &&
+    storedTemp <= cfg.tempLimitsMax;
+
+  if (isValidStoredTemp) {
+    log.debug(
+      'Restored targetTemp="{}" for scenario="{}"',
+      storedTemp,
+      self.idPrefix
+    );
+    return storedTemp;
+  } else {
+    // Either no stored value, or it's out of range
+    var usedTemp = cfg.targetTemp;
+    self.ctx.ps[self.idPrefix].targetTemp = usedTemp;
+
+    // Show warning only if something was stored but invalid
+    if (typeof storedTemp === 'number') {
+      log.warning(
+        'Stored temp="{}" is out of range or invalid for "{}". Reset to "{}"',
+        storedTemp,
+        self.idPrefix,
+        usedTemp
+      );
+    }
+    return usedTemp;
+  }
+}
+
+/**
+ * Creates all required rules for current type scenario
+ * @param {Object} self - Reference to the ThermostatScenario instance
+ * @param {ThermostatConfig} cfg - Configuration object
+ * @returns {boolean} True if all rules created successfully, false otherwise
+ */
+function createRules(self, cfg) {
+  var vdCtrlCurTemp = self.vd.devObj.getControl(vdCtrl.curTemp);
+  var vdCtrlActuator = self.vd.devObj.getControl(vdCtrl.actuatorStatus);
+  var vdCtrlTargetTemp = self.vd.devObj.getControl(vdCtrl.targetTemp);
+  var vdCtrlEnable = self.vd.devObj.getControl(vdCtrl.ruleEnabled);
 
   var ruleCfg = {};
   var ruleId = null;
 
+  // Temperature changed rule
   ruleCfg = {
     whenChanged: [cfg.tempSensor],
     then: function (newValue, devName, cellName) {
@@ -402,25 +445,37 @@ function createRules(cfg, genNames, vdObj, managedRulesId, idPrefix) {
       updateHeatingState(cfg.actuator, data);
     },
   };
-  ruleId = defineRule(genNames.ruleTempChanged, ruleCfg);
-  managedRulesId.push(ruleId);
+  ruleId = defineRule(self.genNames.ruleTempChanged, ruleCfg);
+
+  if (!ruleId) {
+    log.error('Failed to create temperature changed rule');
+    return false;
+  }
+  self.addRule(ruleId);
   log.debug('Temperature changed rule created success with ID "{}"', ruleId);
 
+  // Sync actuator status rule
   ruleCfg = {
     whenChanged: [cfg.actuator],
     then: function (newValue, devName, cellName) {
       vdCtrlActuator.setValue(newValue);
     },
   };
-  ruleId = defineRule(genNames.ruleSyncActStatus, ruleCfg);
-  managedRulesId.push(ruleId);
+  ruleId = defineRule(self.genNames.ruleSyncActStatus, ruleCfg);
+
+  if (!ruleId) {
+    log.error('Failed to create sync actuator status rule');
+    return false;
+  }
+  self.addRule(ruleId);
   log.debug(
     'Sync actuator status rule created success with ID "{}"',
     ruleId
   );
 
+  // Scenario status rule
   ruleCfg = {
-    whenChanged: [genNames.vDevice + '/' + vdCtrl.ruleEnabled],
+    whenChanged: [self.genNames.vDevice + '/' + vdCtrl.ruleEnabled],
     then: function (newValue, devName, cellName) {
       if (newValue) {
         var data = {
@@ -438,25 +493,28 @@ function createRules(cfg, genNames, vdObj, managedRulesId, idPrefix) {
       }
     },
   };
-  ruleId = defineRule(genNames.ruleSetScStatus, ruleCfg);
-  // This rule not disable when user use switch in virtual device
-  log.debug(
-    'Activate scenario status rule created success with ID "{}"',
-    ruleId
-  );
+  ruleId = defineRule(self.genNames.ruleSetScStatus, ruleCfg);
 
+  if (!ruleId) {
+    log.error('Failed to create scenario status rule');
+    return false;
+  }
+  // This rule is not managed when user use switch enable/disable in vdev
+  log.debug('Scenario status rule created with ID "{}"', ruleId);
+
+  // Target temperature change rule
   ruleCfg = {
-    whenChanged: [genNames.vDevice + '/' + vdCtrl.targetTemp],
+    whenChanged: [self.genNames.vDevice + '/' + vdCtrl.targetTemp],
     then: function (newValue, devName, cellName) {
 
       // Save the new temperature to persistent storage
-      if (ps && typeof ps[idPrefix] !== 'undefined') {
+      if (self.ctx.ps && typeof self.ctx.ps[self.idPrefix] !== 'undefined') {
         try {
-          ps[idPrefix].targetTemp = newValue;
+          self.ctx.ps[self.idPrefix].targetTemp = newValue;
           log.debug(
             'Target temperature "{}" saved in persistent storage for scenario="{}"',
             newValue,
-            idPrefix
+            self.idPrefix
           );
         } catch (err) {
           log.error('Error saving target temperature to storage: {}', err);
@@ -472,154 +530,88 @@ function createRules(cfg, genNames, vdObj, managedRulesId, idPrefix) {
       updateHeatingState(cfg.actuator, data);
     },
   };
-  ruleId = defineRule(genNames.ruleSetTargetTemp, ruleCfg);
-  managedRulesId.push(ruleId);
+  ruleId = defineRule(self.genNames.ruleSetTargetTemp, ruleCfg);
+
+  if (!ruleId) {
+    log.error('Failed to create target temperature change rule');
+    return false;
+  }
+  self.addRule(ruleId);
   log.debug('Target temp change rule created success with ID "{}"', ruleId);
 
+  // Error handling rules
   var sensorErrTopic = cfg.tempSensor + '#error';
   ruleId = createErrChangeRule(
-    genNames.ruleSensorErr,
+    self,
+    self.genNames.ruleSensorErr,
     sensorErrTopic,
     vdCtrlCurTemp,
     vdCtrlEnable,
     cfg
   );
+  if (!ruleId) {
+    log.error('Failed to create tempSensor error handling rule');
+    return false;
+  }
   // This rule not disable when user use switch in virtual device
   log.debug('Temp. sensor error handling rule created with ID="{}"', ruleId);
 
   var actuatorErrTopic = cfg.actuator + '#error';
   ruleId = createErrChangeRule(
-    genNames.ruleActuatorErr,
+    self,
+    self.genNames.ruleActuatorErr,
     actuatorErrTopic,
     vdCtrlActuator,
     vdCtrlEnable,
     cfg
   );
-  // This rule not disable when user use switch in virtual device
-  log.debug('Actuator error handling rule created with ID="{}"', ruleId);
-}
-
-/**
- * Restore target temperature from persistent storage (if saved previosly)
- * If the stored value is invalid or missing, we use cfg.targetTemp and save it
- * @param {string} idPrefix Unique identifier of the scenario
- * @param {Object} cfg Thermostat config (tempLimitsMin, tempLimitsMax, etc.)
- * @returns {number} The target temperature to use
- */
-function restoreTargetTemperature(idPrefix, cfg) {
-  if (typeof ps[idPrefix] === 'undefined') {
-    try {
-      ps[idPrefix] = StorableObject({});
-    } catch (err) {
-      log.error('Error on ps[idPrefix] assignment: {}', err);
-      return cfg.targetTemp;
-    }
-
-    log.debug(
-      'Created new record in persistent storage for scenario="{}"',
-      idPrefix
-    );
-  }
-
-  var storedTemp = ps[idPrefix].targetTemp;
-  var isValidStoredTemp =
-    typeof storedTemp === 'number' &&
-    storedTemp >= cfg.tempLimitsMin &&
-    storedTemp <= cfg.tempLimitsMax;
-
-  if (isValidStoredTemp) {
-    log.debug(
-      'Restored targetTemp="{}" for scenario="{}"',
-      storedTemp,
-      idPrefix
-    );
-    return storedTemp;
-  } else {
-    // Either no stored value, or it's out of range
-    var usedTemp = cfg.targetTemp;
-    ps[idPrefix].targetTemp = usedTemp;
-
-    // Show warning only if something was stored but invalid
-    if (typeof storedTemp === 'number') {
-      log.warning(
-        'Stored temp="{}" is out of range or invalid for "{}". Reset to "{}"',
-        storedTemp,
-        idPrefix,
-        usedTemp
-      );
-    }
-    return usedTemp;
-  }
-}
-
-/**
- * Initializes a virtual device and defines a rule
- * for controlling the device
- * @param {string} deviceTitle Name of the virtual device
- * @param {ThermostatConfig} cfg Configuration parameters
- * @returns {boolean} True if initialization is successful
- *                    False if not successful
- */
-function init(deviceTitle, cfg) {
-  ps = new PersistentStorage('wbscThermostatSettings', { global: true });
-  var idPrefix = helpers.getIdPrefix(deviceTitle, cfg);
-  log.setLabel(loggerFileLabel + '/' + idPrefix);
-  var genNames = generateNames(idPrefix);
-
-  // Create a minimal basic virtual device to indicate errors if they occur
-  var managedRulesId = [];
-  var vdObj = createBasicVd(genNames.vDevice, deviceTitle, managedRulesId);
-  if (vdObj === null) {
+  if (!ruleId) {
+    log.error('Failed to create actuator error handling rule');
     return false;
   }
-
-  // Set up a timer that will wait for initialization
-  // If the topics become available after N seconds, continue
-  var checkIntervalMs = 500;
-  var totalWaitMs = 10000;
-  var elapsedMs = 0;
-  var initStatusCtrl = vdObj.getControl(vdCtrl.initStatus);
-  initStatusCtrl.setValue(2);
-  var waitTimer = setInterval(function () {
-    elapsedMs += checkIntervalMs;
-
-    if (areControlsInited([cfg.tempSensor, cfg.actuator])) {
-      clearInterval(waitTimer);
-      initStatusCtrl.setValue(3);
-
-      if (!isConfigValid(cfg)) {
-        initStatusCtrl.setValue(4);
-        setVdTotalError(vdObj, 'Config not valid');
-        vdObj.getControl(vdCtrl.ruleEnabled).setValue(false);
-        return;
-      }
-
-      var usedTemp = restoreTargetTemperature(idPrefix, cfg);
-      addCustomCellsToVd(vdObj, cfg, usedTemp);
-      createRules(cfg, genNames, vdObj, managedRulesId, idPrefix);
-
-      // Set first heater state after initialisation
-      var data = {
-        curTemp: dev[cfg.tempSensor],
-        targetTemp: dev[genNames.vDevice + '/' + vdCtrl.targetTemp],
-        hysteresis: cfg.hysteresis,
-      };
-      updateHeatingState(cfg.actuator, data);
-
-      initStatusCtrl.setValue(6);
-      log.debug('Thermostat init complete for device "{}".', deviceTitle);
-    } else if (elapsedMs >= totalWaitMs) {
-      initStatusCtrl.setValue(5);
-      clearInterval(waitTimer);
-      setVdTotalError(
-        vdObj,
-        'Linked controls not ready in ' + (elapsedMs / 1000) + 's.'
-      );
-      vdObj.getControl(vdCtrl.ruleEnabled).setValue(false);
-    }
-  }, checkIntervalMs);
+  // This rule not disable when user use switch in virtual device
+  log.debug('Actuator error handling rule created with ID="{}"', ruleId);
 
   return true;
 }
 
-exports.init = init;
+/**
+ * Scenario initialization
+ * @param {string} deviceTitle - Virtual device title
+ * @param {ThermostatConfig} cfg - Configuration object
+ * @returns {boolean} True if initialization succeeded
+ */
+ThermostatScenario.prototype.initSpecific = function (deviceTitle, cfg) {
+  log.debug('Start init thermostat scenario');
+  log.setLabel(loggerFileLabel + '/' + this.idPrefix);
+
+  // Initialize persistent storage
+  this.ctx.ps = new PersistentStorage('wbscThermostatSettings', { global: true });
+
+  // Restore target temperature from storage
+  var usedTemp = restoreTargetTemperature(this, cfg);
+
+  // Add custom controls to virtual device
+  addCustomControlsToVirtualDevice(this, cfg, usedTemp);
+
+  // Create all rules
+  log.debug('Start all required rules creation');
+  var rulesCreated = createRules(this, cfg);
+
+  if (rulesCreated) {
+    // Set initial heater state after initialization
+    var data = {
+      curTemp: dev[cfg.tempSensor],
+      targetTemp: dev[this.genNames.vDevice + '/' + vdCtrl.targetTemp],
+      hysteresis: cfg.hysteresis,
+    };
+    updateHeatingState(cfg.actuator, data);
+
+    this.setState(ScenarioState.NORMAL);
+    log.debug('Thermostat scenario initialized successfully for device "{}"', deviceTitle);
+  }
+
+  return rulesCreated;
+}
+
+exports.ThermostatScenario = ThermostatScenario;

--- a/schema/wb-scenarios.schema.json
+++ b/schema/wb-scenarios.schema.json
@@ -43,6 +43,9 @@
       "type": "object",
       "description": "devicesControl_description",
       "_format": "grid",
+      "options": {
+        "display_required_only": true
+      },
       "properties": {
         "scenarioType": {
           "type": "string",
@@ -79,7 +82,7 @@
           "description": "generalScenarioIdPrefixDescription",
           "_pattern_comment": "Запрещает пробелы, /, +, и #, а также ограничивает строку использованием только цифр, нижнего подчеркивания и английских букв",
           "pattern": "^[0-9a-zA-Z_]+$",
-          "default": "devices_control",
+          "default": "",
           "minLength": 1,
           "maxLength": 120,
           "propertyOrder": 3,
@@ -226,7 +229,6 @@
         "scenarioType",
         "enable",
         "name",
-        "id_prefix",
         "inControls",
         "outControls"
       ]
@@ -285,7 +287,7 @@
           "description": "generalScenarioIdPrefixDescription",
           "_pattern_comment": "Запрещает пробелы, /, +, и #, а также ограничивает строку использованием только цифр, нижнего подчеркивания и английских букв",
           "pattern": "^[0-9a-zA-Z_]+$",
-          "default": "lightControl",
+          "default": "",
           "minLength": 1,
           "maxLength": 120,
           "propertyOrder": 3,

--- a/src/virtual-device-helpers.mod.js
+++ b/src/virtual-device-helpers.mod.js
@@ -7,6 +7,22 @@
  */
 
 /**
+ * Scenario state enum - defines all possible scenario states
+ * Used for setting and checking scenario state in the virtual device
+ * @enum {number}
+ */
+var ScenarioState = {
+  CREATED: 0,
+  INIT_STARTED: 1,
+  WAITING_CONTROLS: 2,
+  LINKED_CONTROLS_READY: 3,
+  CONFIG_INVALID: 4,
+  LINKED_CONTROLS_TIMEOUT: 5,
+  NORMAL: 6,
+  USED_CONTROL_ERROR: 7,
+};
+
+/**
  * Проверяет, существует ли контрол
  *
  * @param {string} controlName - Имя контрола ('deviceName/cellName')
@@ -215,23 +231,27 @@ function createBasicVd(vdName, vdTitle, managedRulesId) {
         ru: 'Инициализация запущена...',
       },
       2: {
-        en: 'Waiting for linked controls 10s...',
-        ru: 'Ожидание связанных контролов 10с...',
+        en: 'Waiting for used channels...',
+        ru: 'Ожидание используемых каналов...',
       },
       3: {
-        en: 'Linked controls ready',
-        ru: 'Связанные контролы готовы' },
+        en: 'Used channels ready',
+        ru: 'Используемые каналы готовы' },
       4: {
         en: 'Config not valid',
         ru: 'Настройки не корректны',
       },
       5: {
-        en: 'Linked controls not ready in 10s',
-        ru: 'Связанные контролы не готовы за 10с',
+        en: 'Used channels not ready',
+        ru: 'Используемые каналы не готовы',
       },
       6: {
         en: 'Normal',
         ru: 'В норме',
+      },
+      7: {
+        en: 'Used channel has error',
+        ru: 'Используемый канал в ошибке',
       },
     },
     order: 100,
@@ -254,6 +274,7 @@ function createBasicVd(vdName, vdTitle, managedRulesId) {
   return vdObj;
 }
 
+exports.ScenarioState = ScenarioState;
 exports.addLinkedControlRO = addLinkedControlRO;
 exports.addGroupTitleRO = addGroupTitleRO;
 exports.addAlarm = addAlarm;

--- a/src/wbsc-scenario-base.mod.js
+++ b/src/wbsc-scenario-base.mod.js
@@ -204,7 +204,7 @@ ScenarioBase.prototype.init = function (name, cfg) {
           log.error('Controls not ready within timeout: {}', err.notReadyCtrlList.join(', '));
           self.setState(ScenarioState.LINKED_CONTROLS_TIMEOUT);
           self.vd.setTotalError('Linked controls not ready in ' + 
-                              ((waitConfig.timeout || WAIT_DEF.CONTROLS_WAIT_TIMEOUT) / 1000) + 's: ' + 
+                              ((waitConfig.timeout || WAIT_DEF.CONTROLS_WAIT_TIMEOUT_MS) / 1000) + 's: ' + 
                               err.notReadyCtrlList.join(', '));
 
           self.disable();
@@ -334,8 +334,8 @@ ScenarioBase.prototype.initSpecific = function (name, cfg) {
  * 
  * @example Returned object structure:
  *   - List of controls to wait for
- *   - Maximum wait time in milliseconds (default from WAIT_DEF.CONTROLS_WAIT_TIMEOUT)
- *   - Polling period in milliseconds (default from WAIT_DEF.CONTROLS_WAIT_PERIOD)
+ *   - Maximum wait time in milliseconds (default from WAIT_DEF.CONTROLS_WAIT_TIMEOUT_MS)
+ *   - Polling period in milliseconds (default from WAIT_DEF.CONTROLS_WAIT_PERIOD_MS)
  * {
  *   controls: ['device1/control1', 'device2/control2'],
  *   timeout: 10000,  // Optional

--- a/src/wbsc-scenario-base.mod.js
+++ b/src/wbsc-scenario-base.mod.js
@@ -7,27 +7,12 @@
 
 var getIdPrefix = require('scenarios-general-helpers.mod').getIdPrefix;
 var createBasicVd = require('virtual-device-helpers.mod').createBasicVd;
+var ScenarioState = require('virtual-device-helpers.mod').ScenarioState;
 var waitControls = require('wbsc-wait-controls.mod').waitControls;
-var isControlReady = require('wbsc-wait-controls.mod').isControlReady;
 var Logger = require('logger.mod').Logger;
 
 var loggerFileLabel = 'WBSC‑base-mod';
 var log = new Logger(loggerFileLabel);
-
-/**
- * Scenario state enum - defines all possible scenario states
- * Used for setting and checking scenario state in the virtual device
- * @enum {number}
- */
-var ScenarioState = {
-  CREATED: 0,
-  INIT_STARTED: 1,
-  WAITING_CONTROLS: 2,
-  LINKED_CONTROLS_READY: 3,
-  CONFIG_INVALID: 4,
-  LINKED_CONTROLS_TIMEOUT: 5,
-  NORMAL: 6,
-};
 
 /**
  * Abstract base class for all scenarios
@@ -205,15 +190,15 @@ ScenarioBase.prototype.init = function (name, cfg) {
     waitControls(
       waitConfig.controls,
       { 
-        timeout: waitConfig.timeout || 5000, 
-        period: waitConfig.period || 500 
+        timeout: waitConfig.timeout || 60000, 
+        period: waitConfig.period || 5000 
       },
       function(err) {
         if (err) {
           log.error('Controls not ready within timeout: {}', err.notReadyCtrlList.join(', '));
           self.setState(ScenarioState.LINKED_CONTROLS_TIMEOUT);
           self.vd.setTotalError('Linked controls not ready in ' + 
-                              ((waitConfig.timeout || 5000) / 1000) + 's: ' + 
+                              ((waitConfig.timeout || 60000) / 1000) + 's: ' + 
                               err.notReadyCtrlList.join(', '));
 
           self.disable();
@@ -355,5 +340,4 @@ ScenarioBase.prototype.defineControlsWaitConfig = function(cfg) {
   return {}; // Empty object by default - no waiting
 };
 
-exports.ScenarioState = ScenarioState;
 exports.ScenarioBase = ScenarioBase;

--- a/src/wbsc-wait-controls.mod.js
+++ b/src/wbsc-wait-controls.mod.js
@@ -7,8 +7,8 @@
 
 // Defaults values
 var WAIT_DEF = {
-  CONTROLS_WAIT_TIMEOUT: 60000,
-  CONTROLS_WAIT_PERIOD: 5000
+  CONTROLS_WAIT_TIMEOUT_MS: 60000, // Millisecons
+  CONTROLS_WAIT_PERIOD_MS: 5000 // Millisecons
 };
 
 /**
@@ -63,8 +63,8 @@ function isControlHealthy(controlPath) {
  *
  * @param {string[]} controls - Array of control paths, e.g. ["wb-gpio/Relay_1", "wb-gpio/Relay_2"]
  * @param {Object} [options] - Configuration options
- * @param {number} [options.timeout=WAIT_DEF.CONTROLS_WAIT_TIMEOUT] - Max waiting time in milliseconds
- * @param {number} [options.period=WAIT_DEF.CONTROLS_WAIT_PERIOD] - Polling period in milliseconds
+ * @param {number} [options.timeout=WAIT_DEF.CONTROLS_WAIT_TIMEOUT_MS] - Max waiting time in milliseconds
+ * @param {number} [options.period=WAIT_DEF.CONTROLS_WAIT_PERIOD_MS] - Polling period in milliseconds
  * @param {Function} callback - Callback called upon success or timeout
  *                                Signature: callback(err, param1, param2, ...)
  *                                where err is null on success or ControlsTimeoutError on failure
@@ -87,8 +87,8 @@ function waitControls(controls, options, callback) {
   }
 
   options = options || {};
-  var timeout = typeof options.timeout !== 'undefined' ? options.timeout : WAIT_DEF.CONTROLS_WAIT_TIMEOUT;
-  var period = typeof options.period !== 'undefined' ? options.period : WAIT_DEF.CONTROLS_WAIT_PERIOD;
+  var timeout = typeof options.timeout !== 'undefined' ? options.timeout : WAIT_DEF.CONTROLS_WAIT_TIMEOUT_MS;
+  var period = typeof options.period !== 'undefined' ? options.period : WAIT_DEF.CONTROLS_WAIT_PERIOD_MS;
 
   if (typeof callback !== 'function') {
     log.error("waitControls() callback parameter is not a function:", 

--- a/src/wbsc-wait-controls.mod.js
+++ b/src/wbsc-wait-controls.mod.js
@@ -140,5 +140,6 @@ function waitControls(controls, options, callback) {
   }, period);
 }
 
+exports.WAIT_DEF = WAIT_DEF;
 exports.waitControls = waitControls;
 exports.hasCriticalErr = hasCriticalErr;

--- a/src/wbsc-wait-controls.mod.js
+++ b/src/wbsc-wait-controls.mod.js
@@ -6,10 +6,42 @@
  */
 
 /**
- * Check if a control is ready
+ * Check if a control is ready (initialized)
+ * @param {string} controlPath - Control path like "device/control"
+ * @returns {boolean} True if control is initialized
  **/
 function isControlReady(controlPath) {
   return dev[controlPath] !== null;
+  // NOTE: May check for this goal and
+  //       dev[topic + '#type'] !== null
+}
+
+/**
+ * Checks if the given error value contains a critical error.
+ * A critical error is defined as a string containing 'r' or 'w'
+ * @param {string|undefined} errorVal - The error value to check
+ * @returns {boolean} True if there is a critical error, false otherwise
+ */
+function hasCriticalErr(errorVal) {
+  if (typeof errorVal !== 'string') {
+    return false;
+  }
+  return (errorVal.indexOf('r') !== -1 || errorVal.indexOf('w') !== -1);
+}
+
+/**
+ * Check if a control is ready and has no critical errors
+ * @param {string} controlPath - Control path like "device/control"
+ * @returns {boolean} True if control is ready and healthy
+ */
+function isControlHealthy(controlPath) {
+  if (!isControlReady(controlPath)) {
+    return false;
+  }
+  if (hasCriticalErr(dev[controlPath  + '#error'])) {
+    return false;
+  }
+  return true;
 }
 
 /**
@@ -25,8 +57,8 @@ function isControlReady(controlPath) {
  *
  * @param {string[]} controls - Array of control paths, e.g. ["wb-gpio/Relay_1", "wb-gpio/Relay_2"]
  * @param {Object} [options] - Configuration options
- * @param {number} [options.timeout=5000] - Max waiting time in milliseconds
- * @param {number} [options.period=500] - Polling period in milliseconds
+ * @param {number} [options.timeout=60000] - Max waiting time in milliseconds
+ * @param {number} [options.period=5000] - Polling period in milliseconds
  * @param {Function} callback - Callback called upon success or timeout
  *                                Signature: callback(err, param1, param2, ...)
  *                                where err is null on success or ControlsTimeoutError on failure
@@ -35,7 +67,7 @@ function isControlReady(controlPath) {
  * @example
  *   // Without options - used default timeout and polling period options
  *   waitControls(controls, callback, param1);
- *   // With options - change default 5000ms/500ms to 9000ms/100ms
+ *   // With options - change default 60000ms/5000ms to 9000ms/100ms
  *   waitControls(controls, { timeout: 9000, period: 100 }, callback, param1);
  **/
 function waitControls(controls, options, callback) {
@@ -49,8 +81,8 @@ function waitControls(controls, options, callback) {
   }
 
   options = options || {};
-  var timeout = typeof options.timeout !== 'undefined' ? options.timeout : 5000;
-  var period = typeof options.period !== 'undefined' ? options.period : 500;
+  var timeout = typeof options.timeout !== 'undefined' ? options.timeout : 60000;
+  var period = typeof options.period !== 'undefined' ? options.period : 5000;
 
   if (typeof callback !== 'function') {
     log.error("waitControls() callback parameter is not a function:", 
@@ -71,7 +103,7 @@ function waitControls(controls, options, callback) {
   var intervalId = setInterval(function() {
     var allReady = true;
     for (var i = 0; i < controls.length; i++) {
-      if (!isControlReady(controls[i])) {
+      if (!isControlHealthy(controls[i])) {
         allReady = false;
         break;
       }
@@ -90,7 +122,7 @@ function waitControls(controls, options, callback) {
 
       err.notReadyCtrlList = [];
       for (var i = 0; i < controls.length; i++) {
-        if (!isControlReady(controls[i])) {
+        if (!isControlHealthy(controls[i])) {
           err.notReadyCtrlList.push(controls[i]);
         }
       }
@@ -103,3 +135,4 @@ function waitControls(controls, options, callback) {
 }
 
 exports.waitControls = waitControls;
+exports.hasCriticalErr = hasCriticalErr;

--- a/src/wbsc-wait-controls.mod.js
+++ b/src/wbsc-wait-controls.mod.js
@@ -5,6 +5,12 @@
  * @author Vitalii Gaponov <vitalii.gaponov@wirenboard.com>
  */
 
+// Defaults values
+var WAIT_DEF = {
+  CONTROLS_WAIT_TIMEOUT: 60000,
+  CONTROLS_WAIT_PERIOD: 5000
+};
+
 /**
  * Check if a control is ready (initialized)
  * @param {string} controlPath - Control path like "device/control"
@@ -57,8 +63,8 @@ function isControlHealthy(controlPath) {
  *
  * @param {string[]} controls - Array of control paths, e.g. ["wb-gpio/Relay_1", "wb-gpio/Relay_2"]
  * @param {Object} [options] - Configuration options
- * @param {number} [options.timeout=60000] - Max waiting time in milliseconds
- * @param {number} [options.period=5000] - Polling period in milliseconds
+ * @param {number} [options.timeout=WAIT_DEF.CONTROLS_WAIT_TIMEOUT] - Max waiting time in milliseconds
+ * @param {number} [options.period=WAIT_DEF.CONTROLS_WAIT_PERIOD] - Polling period in milliseconds
  * @param {Function} callback - Callback called upon success or timeout
  *                                Signature: callback(err, param1, param2, ...)
  *                                where err is null on success or ControlsTimeoutError on failure
@@ -81,8 +87,8 @@ function waitControls(controls, options, callback) {
   }
 
   options = options || {};
-  var timeout = typeof options.timeout !== 'undefined' ? options.timeout : 60000;
-  var period = typeof options.period !== 'undefined' ? options.period : 5000;
+  var timeout = typeof options.timeout !== 'undefined' ? options.timeout : WAIT_DEF.CONTROLS_WAIT_TIMEOUT;
+  var period = typeof options.period !== 'undefined' ? options.period : WAIT_DEF.CONTROLS_WAIT_PERIOD;
 
   if (typeof callback !== 'function') {
     log.error("waitControls() callback parameter is not a function:", 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

1) Увеличены таймауты ожидания поллинга контролов с 10 до 60 секунд, тк таймаут 10с при запуске новой версии или переходе на теснинг падал
2) Изменены сообщения в статусах сценариев - переформулированы тк "связанные контролы" были не понятны юзерам

Старая ошибка выглядела так
<img width="474" height="170" alt="image" src="https://github.com/user-attachments/assets/9dfe8baa-0248-43c9-9390-12db956d34f8" />

Во время ожидания переименовали статус и убрали время
<img width="406" height="128" alt="image" src="https://github.com/user-attachments/assets/4aa3f185-a0b7-4241-b879-acb2651c3582" />

При ошибке тоже переформулировали и убрали время
<img width="461" height="122" alt="image" src="https://github.com/user-attachments/assets/eb799f5d-174d-4b13-aae1-298f751cd574" />


3) В ходе фиксов пришлось актуализировать код и документация к термостату, тк он использовал немного отличающуюся логику ожидания от двух других сценариев
Сам функционал сценария не изменен

4) Удалил из обязательных поле id prefix у управления девайсами
Это поле в двух других сценариях уже было скрыто - а тут оно мало того что отображается, так оно еще и обязательное , плюс у него было дефолтное значение прописано и при создании двух сценариев этого типа начинало конфиликтовать - очень не очевидное поведение.

было 
<img width="1280" height="682" alt="image" src="https://github.com/user-attachments/assets/c67c409b-c90c-468d-ab18-d2fdba6caae9" />

Стало

<img width="1280" height="728" alt="image" src="https://github.com/user-attachments/assets/4d5ae748-0d83-4282-ac23-745b36c495b3" />

____________________
**Что поменялось для пользователей:**

Теперь при установке обновлений не должно быть ошибки не созданных девайсов

___________________________________
**Как проверял/а:**

Установил на контроллер

