### PR TITLE
fix: config migration for empty scheduleDaysOfWeek

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-scenarios (1.7.2) stable; urgency=medium
+
+  * Fix: schedule scenarios with empty scheduleDaysOfWeek break web UI on
+    upgrade from v1.7.0. Add config migration system to fill missing days.
+
+ -- Valerii Trovimov <valeriy.trofimov@wirenboard.com>  Fri, 27 Feb 2026 12:00:00 +0300
+
 wb-scenarios (1.7.1) stable; urgency=medium
 
   * All days of the week are selected by default

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,7 +3,7 @@ wb-scenarios (1.7.2) stable; urgency=medium
   * Fix: schedule scenarios with empty scheduleDaysOfWeek break web UI on
     upgrade from v1.7.0. Add config migration system to fill missing days.
 
- -- Valerii Trovimov <valeriy.trofimov@wirenboard.com>  Fri, 27 Feb 2026 12:00:00 +0300
+ -- Andrey Ksenofontov <andrey.ksenofontov@wirenboard.com>  Fri, 27 Feb 2026 19:30:16 +0300
 
 wb-scenarios (1.7.1) stable; urgency=medium
 

--- a/scenarios/scenario-init-main.js
+++ b/scenarios/scenario-init-main.js
@@ -85,14 +85,29 @@ function migrateConfig() {
   if (latestVersion > currentVersion) {
     config.configMigrationVersion = latestVersion;
     var json = JSON.stringify(config, null, 4);
-    runShellCommand(
-      "cat > " + CONFIG_PATH + " << 'WBEOF'\n" + json + "\nWBEOF"
-    );
-    log.info(
-      'Config migrated from v{} to v{}',
-      currentVersion,
-      latestVersion
-    );
+    runShellCommand('cat > ' + CONFIG_PATH, {
+      input: json,
+      captureErrorOutput: true,
+      exitCallback: function exitWriteConfig(
+        exitCode,
+        capturedOutput,
+        capturedErrorOutput
+      ) {
+        if (exitCode !== 0) {
+          log.error(
+            'Failed to write migrated config (exit code {}): {}',
+            exitCode,
+            capturedErrorOutput
+          );
+          return;
+        }
+        log.info(
+          'Config migrated from v{} to v{}',
+          currentVersion,
+          latestVersion
+        );
+      },
+    });
   }
 }
 

--- a/scenarios/scenario-init-main.js
+++ b/scenarios/scenario-init-main.js
@@ -21,7 +21,84 @@ var Logger = require('logger.mod').Logger;
 
 var log = new Logger('WBSC-init-main');
 
+var CONFIG_PATH = '/etc/wb-scenarios.conf';
+
+/**
+ * List of migrations. Each has a version number and a function
+ * that mutates the config object. Migrations run in order,
+ * only if configMigrationVersion < migration version.
+ */
+var MIGRATIONS = [
+  {
+    version: 1,
+    description:
+      'Set default days for schedule scenarios with empty scheduleDaysOfWeek',
+    run: function migrateEmptyDaysOfWeek(config) {
+      var ALL_DAYS = [
+        'monday',
+        'tuesday',
+        'wednesday',
+        'thursday',
+        'friday',
+        'saturday',
+        'sunday',
+      ];
+      for (var i = 0; i < config.scenarios.length; i++) {
+        var s = config.scenarios[i];
+        if (
+          s.scenarioType === 'schedule' &&
+          Array.isArray(s.scheduleDaysOfWeek) &&
+          s.scheduleDaysOfWeek.length === 0
+        ) {
+          s.scheduleDaysOfWeek = ALL_DAYS;
+        }
+      }
+    },
+  },
+];
+
+/**
+ * Runs all pending migrations on the config file.
+ * Reads config, applies migrations with version > current,
+ * writes back if changed.
+ */
+function migrateConfig() {
+  var config = readConfig(CONFIG_PATH);
+  if (!config || !Array.isArray(config.scenarios)) return;
+
+  var currentVersion = config.configMigrationVersion || 0;
+  var latestVersion = currentVersion;
+
+  for (var i = 0; i < MIGRATIONS.length; i++) {
+    var migration = MIGRATIONS[i];
+    if (migration.version > currentVersion) {
+      log.info(
+        'Running migration v{}: {}',
+        migration.version,
+        migration.description
+      );
+      migration.run(config);
+      latestVersion = migration.version;
+    }
+  }
+
+  if (latestVersion > currentVersion) {
+    config.configMigrationVersion = latestVersion;
+    var json = JSON.stringify(config, null, 4);
+    runShellCommand(
+      "cat > " + CONFIG_PATH + " << 'WBEOF'\n" + json + "\nWBEOF"
+    );
+    log.info(
+      'Config migrated from v{} to v{}',
+      currentVersion,
+      latestVersion
+    );
+  }
+}
+
 function main() {
+  migrateConfig();
+
   log.debug('Start initialisation all types scenarios');
 
   // Retrieving all previously created virtual devices from persistent storage

--- a/schema/wb-scenarios.schema.json
+++ b/schema/wb-scenarios.schema.json
@@ -989,6 +989,15 @@
         "hidden": true
       }
     },
+    "configMigrationVersion": {
+      "type": "integer",
+      "title": "Config migration version",
+      "default": 0,
+      "minimum": 0,
+      "options": {
+        "hidden": true
+      }
+    },
     "scenarios": {
       "type": "array",
       "title": "Scenarios",


### PR DESCRIPTION
## Summary

- Schedule scenarios saved with empty `scheduleDaysOfWeek: []` in v1.7.0 break the web UI after upgrade to v1.7.1 (which added `minItems: 1` validation in JSON schema)
- Added a versioned config migration system to `scenario-init-main.js` that runs before scenario initialization
- Migration v1 fills empty `scheduleDaysOfWeek` arrays with all 7 days; scenarios with non-empty arrays are not affected
- Migration version tracked via `configMigrationVersion` field in config, ensuring each migration runs exactly once

## Test plan

- [x] Config with `scheduleDaysOfWeek: []` — empty array replaced with all 7 days
- [x] Config with non-empty `scheduleDaysOfWeek` — not modified
- [x] `configMigrationVersion: 1` written to config after migration
- [x] Idempotency: repeated restart does not rewrite config (md5 unchanged)
- [ ] Web UI "Сценарии" tab opens without errors after upgrade

Tested on hardware: `wirenboard-AWHTQ4IF`

🤖 Generated with [Claude Code](https://claude.com/claude-code)