### PR TITLE
fix: update thermostat migration

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
-wb-scenarios (1.7.9) stable; urgency=medium
+wb-scenarios (1.8.0) stable; urgency=medium
 
-  * Fix thermostat migration
+  * Update thermostat migration
 
  -- Valerii Trovimov <valeriy.trofimov@wirenboard.com>  Wed, 25 Mar 2026 12:43:00 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,12 @@ wb-scenarios (1.7.9) stable; urgency=medium
 
   * Fix thermostat migration
 
+ -- Valerii Trovimov <valeriy.trofimov@wirenboard.com>  Wed, 25 Mar 2026 12:43:00 +0300
+
+wb-scenarios (1.7.9) stable; urgency=medium
+
+  * Fix thermostat migration
+
  -- Valerii Trovimov <valeriy.trofimov@wirenboard.com>  Tue, 24 Mar 2026 18:32:00 +0300
 
 wb-scenarios (1.7.8) stable; urgency=medium

--- a/debian/postinst
+++ b/debian/postinst
@@ -3,7 +3,6 @@ set -e
 
 DATA_CONFIG="/mnt/data/etc/wb-scenarios.conf"
 
-# Должны менять только основной файл от которого идет симлинк. Нужно проверить, что не ломается симлинк
 # Migration: thermostat actuator (string) -> actuators (array)
 # Added in 1.7.6 (2026-03-20)
 # Converts old single-actuator config to new multi-actuator format

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,7 +1,6 @@
 #!/bin/sh
 set -e
 
-# CONFIG="/etc/wb-scenarios.conf"
 DATA_CONFIG="/mnt/data/etc/wb-scenarios.conf"
 
 # Должны менять только основной файл от которого идет симлинк. Нужно проверить, что не ломается симлинк
@@ -17,13 +16,11 @@ migrate_config() {
             jq '(.scenarios[] | select(.scenarioType == "thermostat" and .actuator != null)) |=
                 (. + { actuators: [{ mqttTopicName: .actuator, behaviorType: "setEnable" }] } | del(.actuator))
             ' "$cfg" > "$TMP" && mv "$TMP" "$cfg"
-            echo "wb-scenarios: migrated thermostat actuator -> actuators"
         fi
     fi
 }
 
 if [ "$1" = "configure" ]; then
-    # migrate_config "$CONFIG"
     migrate_config "$DATA_CONFIG"
 fi
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -17,6 +17,7 @@ migrate_config() {
             jq '(.scenarios[] | select(.scenarioType == "thermostat" and .actuator != null)) |=
                 (. + { actuators: [{ mqttTopicName: .actuator, behaviorType: "setEnable" }] } | del(.actuator))
             ' "$cfg" > "$TMP" && mv "$TMP" "$cfg"
+            echo "wb-scenarios: migrated thermostat actuator -> actuators"
         fi
     fi
 }

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,9 +1,10 @@
 #!/bin/sh
 set -e
 
-CONFIG="/etc/wb-scenarios.conf"
+# CONFIG="/etc/wb-scenarios.conf"
 DATA_CONFIG="/mnt/data/etc/wb-scenarios.conf"
 
+# Должны менять только основной файл от которого идет симлинк. Нужно проверить, что не ломается симлинк
 # Migration: thermostat actuator (string) -> actuators (array)
 # Added in 1.7.6 (2026-03-20)
 # Converts old single-actuator config to new multi-actuator format
@@ -21,7 +22,7 @@ migrate_config() {
 }
 
 if [ "$1" = "configure" ]; then
-    migrate_config "$CONFIG"
+    # migrate_config "$CONFIG"
     migrate_config "$DATA_CONFIG"
 fi
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Прошлый PR с обновлением миграций был с ошибкой, что приводило к сбросу изменений сценариев и созданных сценариев, потому что ломался симлинк. Теперь миграция устанавливается правильно и конфиг сохраняется корректно.

___________________________________
**Что поменялось для пользователей:**

Теперь точно не будет проблем при обновлении версии пакета)

___________________________________
**Как проверял/а:**

Проверял локально, ставил конфиг термостата старого типа, переустанавливал пакет. Проверял, что вкладка открывается, сценарий работает и симлинк не сломан. Далее создавал сценарий и обновлял текущий сценарий термостата, а после перезагружал контроллер и проверял, что изменения не затерлись.

