### PR TITLE
feat: Hide enable property INT-1004

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-scenarios (1.8.9) stable; urgency=medium
+
+  * Hide enable property
+
+ -- Valerii Trovimov <valeriy.trofimov@wirenboard.com>  Tue, 28 Apr 2026 11:21:00 +0300
+
 wb-scenarios (1.8.8) stable; urgency=medium
 
   * Сodestyle conversion

--- a/scenarios/devices-control/scenario-init-devices-control.mod.js
+++ b/scenarios/devices-control/scenario-init-devices-control.mod.js
@@ -85,6 +85,8 @@ function findAllActiveScenariosWithType(listScenario, searchScenarioType) {
     // The `enable` field was intended to be removed completely, but was hidden instead
     // to maintain backward compatibility with older package versions. Some users may still
     // have this field set to `false` in their configs.
+    // IMPORTANT: Removing this check would re-enable scenarious that were explicitly disabled,
+    // potentially causing unintended behavior.
     var isEnabled =
       scenario.hasOwnProperty('enable') && scenario.enable === false
         ? false

--- a/scenarios/devices-control/scenario-init-devices-control.mod.js
+++ b/scenarios/devices-control/scenario-init-devices-control.mod.js
@@ -82,7 +82,9 @@ function findAllActiveScenariosWithType(listScenario, searchScenarioType) {
   var matchedScenarios = [];
   for (var i = 0; i < listScenario.length; i++) {
     var scenario = listScenario[i];
-    // The 'enable' field has been hidden, but we need to keep it running for now
+    // The `enable` field was intended to be removed completely, but was hidden instead
+    // to maintain backward compatibility with older package versions. Some users may still
+    // have this field set to `false` in their configs.
     var isEnabled =
       scenario.hasOwnProperty('enable') && scenario.enable === false
         ? false

--- a/scenarios/devices-control/scenario-init-devices-control.mod.js
+++ b/scenarios/devices-control/scenario-init-devices-control.mod.js
@@ -82,9 +82,12 @@ function findAllActiveScenariosWithType(listScenario, searchScenarioType) {
   var matchedScenarios = [];
   for (var i = 0; i < listScenario.length; i++) {
     var scenario = listScenario[i];
-    var isTarget =
-      scenario.scenarioType === searchScenarioType &&
-      scenario.enable === true;
+    // The 'enable' field has been hidden, but we need to keep it running for now
+    var isEnabled =
+      scenario.hasOwnProperty('enable') && scenario.enable === false
+        ? false
+        : true;
+    var isTarget = scenario.scenarioType === searchScenarioType && isEnabled;
     if (isTarget) {
       matchedScenarios.push(scenario);
     }

--- a/scenarios/schedule/scenario-init-schedule.mod.js
+++ b/scenarios/schedule/scenario-init-schedule.mod.js
@@ -79,7 +79,9 @@ function findAllActiveScenariosWithType(listScenario, searchScenarioType) {
   var matchedScenarios = [];
   for (var i = 0; i < listScenario.length; i++) {
     var scenario = listScenario[i];
-    // The 'enable' field has been hidden, but we need to keep it running for now
+    // The `enable` field was intended to be removed completely, but was hidden instead
+    // to maintain backward compatibility with older package versions. Some users may still
+    // have this field set to `false` in their configs.
     var isEnabled =
       scenario.hasOwnProperty('enable') && scenario.enable === false
         ? false

--- a/scenarios/schedule/scenario-init-schedule.mod.js
+++ b/scenarios/schedule/scenario-init-schedule.mod.js
@@ -79,9 +79,12 @@ function findAllActiveScenariosWithType(listScenario, searchScenarioType) {
   var matchedScenarios = [];
   for (var i = 0; i < listScenario.length; i++) {
     var scenario = listScenario[i];
-    var isTarget =
-      scenario.scenarioType === searchScenarioType &&
-      scenario.enable === true;
+    // The 'enable' field has been hidden, but we need to keep it running for now
+    var isEnabled =
+      scenario.hasOwnProperty('enable') && scenario.enable === false
+        ? false
+        : true;
+    var isTarget = scenario.scenarioType === searchScenarioType && isEnabled;
     if (isTarget) {
       matchedScenarios.push(scenario);
     }

--- a/scenarios/schedule/scenario-init-schedule.mod.js
+++ b/scenarios/schedule/scenario-init-schedule.mod.js
@@ -82,6 +82,8 @@ function findAllActiveScenariosWithType(listScenario, searchScenarioType) {
     // The `enable` field was intended to be removed completely, but was hidden instead
     // to maintain backward compatibility with older package versions. Some users may still
     // have this field set to `false` in their configs.
+    // IMPORTANT: Removing this check would re-enable scenarious that were explicitly disabled,
+    // potentially causing unintended behavior.
     var isEnabled =
       scenario.hasOwnProperty('enable') && scenario.enable === false
         ? false

--- a/schema/wb-scenarios.schema.json
+++ b/schema/wb-scenarios.schema.json
@@ -247,13 +247,7 @@
           }
         }
       },
-      "required": [
-        "scenarioType",
-        "enable",
-        "name",
-        "inControls",
-        "outControls"
-      ]
+      "required": ["scenarioType", "name", "inControls", "outControls"]
     },
     "lightControl": {
       "title": "lightControlScenarioName",
@@ -1181,7 +1175,6 @@
       "required": [
         "scenarioType",
         "componentVersion",
-        "enable",
         "name",
         "scheduleTime",
         "scheduleDaysOfWeek",


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Создал PR на основе текущего, изменения смотреть в пятом коммите. 

Скрыты поля enable в сценарии Автоматизация и Расписание. При обновлении, поля продолжают работать штатно, если создать новый сценарий, то они по умолчанию будут скрыты. Если поле добавлено в конфиг и имеет False значение, то сценарий корректно не создается.

___________________________________
**Что поменялось для пользователей:**

Скрыли поле, которые сбивало с толку пользователей, при желании они смогут его использовать.

___________________________________
**Как проверял/а:**

Проверял локально на контроллере.