### PR TITLE
fix: stop clearing fired timers in light-control scenario INT-1104

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-scenarios (1.9.4) stable; urgency=medium
+
+  * Fix light-control: stop clearing already-fired countdown timers
+
+ -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Tue, 09 Jun 2026 12:23:00 +0300
+
 wb-scenarios (1.9.3) stable; urgency=medium
 
   * Update channel-map: added inversion checkbox

--- a/scenarios/light-control/light-control.mod.js
+++ b/scenarios/light-control/light-control.mod.js
@@ -891,6 +891,7 @@ function remainingTimeToLightOffHandler(self, newValue, devName, cellName) {
       clearTimeout(self.ctx.lightOffTimerId);
     }
     self.ctx.lightOffTimerId = setTimeout(function () {
+      self.ctx.lightOffTimerId = null;
       updateRemainingLightOffTime(self);
     }, 1000);
   } else {
@@ -1015,6 +1016,7 @@ function remainingTimeToLogicEnableHandler(
       clearTimeout(self.ctx.logicEnableTimerId);
     }
     self.ctx.logicEnableTimerId = setTimeout(function () {
+      self.ctx.logicEnableTimerId = null;
       updateRemainingLogicEnableTime(self);
     }, 1000);
   } else {


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

В сценарии «Управление светом» во время отсчёта до выключения света в журнал wb-rules каждую секунду падает `ERROR: trying to stop unknown timer`. Воспроизводится у любого с настройкой «датчик движения → лампа с задержкой». Сценарий работает, но в лог пишутся ошибки.

Причина: отсчёт сделан цепочкой `setTimeout` раз в секунду, и на перевзводе вызывается `clearTimeout` по ID таймера, который только что отработал. Аналогично и во втором отсчёте — «Активация автоматики через».

___________________________________
**Что поменялось для пользователей:**

Журнал больше не засоряется ошибками `trying to stop unknown timer`. Логика и тайминги сценария не изменились.

___________________________________
**Как проверял/а:**

На контроллере поднял сетап из тикета и прогнал оба таймера до и после правки:
- выключение света по движению — было 9 ошибок за цикл, стало 0
- активация автоматики после стенового выключателя — было 18 ошибок, стало 0