### PR TITLE
feat: add set color and text for actions via wb-dynamic-type widget INT-1062

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 *.md
+control

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ wb-scenarios (1.9.5) stable; urgency=medium
 
   * Add Set Color and Set Text output for actions
 
- -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Fri, 25 Jun 2026 11:22:00 +0300
+ -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Fri, 25 Jun 2026 18:52:00 +0300
 
 wb-scenarios (1.9.4) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ wb-scenarios (1.9.5) stable; urgency=medium
 
   * Add Set Color and Set Text output for actions
 
- -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Fri, 26 Jun 2026 10:54:00 +0300
+ -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Mon, 29 Jun 2026 16:52:00 +0300
 
 wb-scenarios (1.9.4) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-scenarios (1.9.4) stable; urgency=medium
+
+  * Add Set Color and Set Text output for actions
+
+ -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Tue, 09 Jun 2026 18:55:00 +0300
+
 wb-scenarios (1.9.3) stable; urgency=medium
 
   * Update channel-map: added inversion checkbox

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ wb-scenarios (1.9.5) stable; urgency=medium
 
   * Add Set Color and Set Text output for actions
 
- -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Fri, 25 Jun 2026 18:52:00 +0300
+ -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Fri, 26 Jun 2026 10:54:00 +0300
 
 wb-scenarios (1.9.4) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
 wb-scenarios (1.9.5) stable; urgency=medium
 
-  * Add Set Color and Set Text output for actions
+  * Add Set Color and Set Text for output actions via wb-dynamic-type widget
 
- -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Mon, 29 Jun 2026 16:52:00 +0300
+ -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Tue, 30 Jun 2026 10:21:00 +0300
 
 wb-scenarios (1.9.4) stable; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Architecture: all
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          wb-rules (>= 2.20.0~~),
-         wb-mqtt-homeui (>= 2.236.0~~)
+         wb-mqtt-homeui (>= 2.236.1~~)
 Description: Scenarios for Wiren Board
  This package provides ready-to-use scripts
  to connect devices and link them together more quickly.

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Architecture: all
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          wb-rules (>= 2.20.0~~),
-         wb-mqtt-homeui (>= 2.180.0~~)
+         wb-mqtt-homeui (>= 2.234.0~~)
 Description: Scenarios for Wiren Board
  This package provides ready-to-use scripts
  to connect devices and link them together more quickly.

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Architecture: all
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          wb-rules (>= 2.20.0~~),
-         wb-mqtt-homeui (>= 2.234.0~~)
+         wb-mqtt-homeui (>= 2.236.0~~)
 Description: Scenarios for Wiren Board
  This package provides ready-to-use scripts
  to connect devices and link them together more quickly.

--- a/scenarios/periodic-timer/periodic-timer.mod.js
+++ b/scenarios/periodic-timer/periodic-timer.mod.js
@@ -28,6 +28,15 @@ var periodicTimerActionsTable = {
   setEnable: aTable.actionsTable.setEnable,
   setDisable: aTable.actionsTable.setDisable,
   setValue: aTable.actionsTable.setValue,
+  setText: aTable.actionsTable.setText,
+  setColor: aTable.actionsTable.setColor,
+};
+
+// Actions that carry a payload in initValue/reverseValue (vs. on/off actions)
+var VALUE_BEARING_ACTIONS = {
+  setValue: true,
+  setText: true,
+  setColor: true,
 };
 
 var loggerFileLabel = 'WBSC-periodic-timer-mod';
@@ -59,9 +68,9 @@ var MAX_DAYS_AHEAD = 8; // today + 7
 /**
  * @typedef {Object} ControlConfig
  * @property {string} mqttTopicName - MQTT topic 'device/control'
- * @property {'setEnable'|'setDisable'|'setValue'} behaviorType
- * @property {number} [initValue] - setValue: value to apply on start
- * @property {number} [reverseValue] - setValue: value to restore on stop
+ * @property {'setEnable'|'setDisable'|'setValue'|'setText'|'setColor'} behaviorType
+ * @property {number|string} [initValue] - value-bearing actions: value to apply on start
+ * @property {number|string} [reverseValue] - value-bearing actions: value to restore on stop
  */
 
 /**
@@ -162,20 +171,28 @@ function validateControls(controls, table) {
       );
       return false;
     }
-    if (ctrl.behaviorType === 'setValue') {
-      if (typeof ctrl.initValue !== 'number') {
+    if (VALUE_BEARING_ACTIONS[ctrl.behaviorType]) {
+      if (ctrl.initValue === undefined || ctrl.reverseValue === undefined) {
         log.error(
-          "Periodic Timer validation error: control '{}': initValue must be a number",
-          ctrl.mqttTopicName
+          "Periodic Timer validation error: control '{}': initValue and reverseValue are required for '{}'",
+          ctrl.mqttTopicName,
+          ctrl.behaviorType
         );
         return false;
       }
-      if (typeof ctrl.reverseValue !== 'number') {
-        log.error(
-          "Periodic Timer validation error: control '{}': reverseValue must be a number",
-          ctrl.mqttTopicName
-        );
-        return false;
+      // setValue accepts numbers stored as number or numeric string;
+      // setText/setColor carry strings, so only setValue needs the numeric check
+      if (ctrl.behaviorType === 'setValue') {
+        if (
+          isNaN(Number(ctrl.initValue)) ||
+          isNaN(Number(ctrl.reverseValue))
+        ) {
+          log.error(
+            "Periodic Timer validation error: control '{}': initValue and reverseValue must be numeric",
+            ctrl.mqttTopicName
+          );
+          return false;
+        }
       }
     }
   }
@@ -649,8 +666,9 @@ function executeReverse(controls) {
           dev[ctrl.mqttTopicName],
           null
         );
-      } else if (ctrl.behaviorType === 'setValue') {
-        newValue = periodicTimerActionsTable.setValue.handler(
+      } else if (VALUE_BEARING_ACTIONS[ctrl.behaviorType]) {
+        // setValue/setText/setColor: reverse applies reverseValue with the same handler
+        newValue = periodicTimerActionsTable[ctrl.behaviorType].handler(
           dev[ctrl.mqttTopicName],
           ctrl.reverseValue
         );

--- a/schema/wb-scenarios.schema.json
+++ b/schema/wb-scenarios.schema.json
@@ -181,7 +181,7 @@
             }
           },
           "items": {
-            "id": "devicesControlActionItem",
+            "id": "urn:wb:devicesControlActionItem",
             "title": "generalActionObjTitle",
             "type": "object",
             "properties": {
@@ -239,7 +239,7 @@
                 "default": "",
                 "watch": {
                   "wbActionType": [
-                    "devicesControlActionItem",
+                    "urn:wb:devicesControlActionItem",
                     "behaviorType"
                   ]
                 },
@@ -1124,7 +1124,7 @@
             }
           },
           "items": {
-            "id": "scheduleActionItem",
+            "id": "urn:wb:scheduleActionItem",
             "title": "generalActionObjTitle",
             "type": "object",
             "properties": {
@@ -1181,7 +1181,10 @@
                 "description": "outControls_actionValue_description",
                 "default": "",
                 "watch": {
-                  "wbActionType": ["scheduleActionItem", "behaviorType"]
+                  "wbActionType": [
+                    "urn:wb:scheduleActionItem",
+                    "behaviorType"
+                  ]
                 },
                 "options": {
                   "dependencies": {
@@ -1419,6 +1422,7 @@
             }
           },
           "items": {
+            "id": "urn:wb:astronomicalTimerActionItem",
             "title": "generalActionObjTitle",
             "type": "object",
             "properties": {
@@ -1450,7 +1454,9 @@
                   "setDisable",
                   "setValue",
                   "increaseValueBy",
-                  "decreaseValueBy"
+                  "decreaseValueBy",
+                  "setText",
+                  "setColor"
                 ],
                 "default": "setDisable",
                 "options": {
@@ -1460,22 +1466,32 @@
                     "Disable (switch)",
                     "generalEnumSetValue",
                     "Increase Value By",
-                    "Decrease Value By"
+                    "Decrease Value By",
+                    "generalEnumSetText",
+                    "generalEnumSetColor"
                   ]
                 }
               },
               "actionValue": {
-                "type": "number",
+                "_format": "wb-action-value",
                 "propertyOrder": 3,
                 "title": "generalActionValueTitle",
                 "description": "outControls_actionValue_description",
-                "default": 0,
+                "default": "",
+                "watch": {
+                  "wbActionType": [
+                    "urn:wb:astronomicalTimerActionItem",
+                    "behaviorType"
+                  ]
+                },
                 "options": {
                   "dependencies": {
                     "behaviorType": [
                       "setValue",
                       "increaseValueBy",
-                      "decreaseValueBy"
+                      "decreaseValueBy",
+                      "setText",
+                      "setColor"
                     ]
                   }
                 }
@@ -1709,7 +1725,7 @@
             }
           },
           "items": {
-            "id": "periodicTimerActionItem",
+            "id": "urn:wb:periodicTimerActionItem",
             "title": "generalActionObjTitle",
             "type": "object",
             "properties": {
@@ -1758,7 +1774,10 @@
                 "title": "periodicTimerInitValueTitle",
                 "default": "",
                 "watch": {
-                  "wbActionType": ["periodicTimerActionItem", "behaviorType"]
+                  "wbActionType": [
+                    "urn:wb:periodicTimerActionItem",
+                    "behaviorType"
+                  ]
                 },
                 "options": {
                   "dependencies": {
@@ -1772,7 +1791,10 @@
                 "title": "periodicTimerReverseValueTitle",
                 "default": "",
                 "watch": {
-                  "wbActionType": ["periodicTimerActionItem", "behaviorType"]
+                  "wbActionType": [
+                    "urn:wb:periodicTimerActionItem",
+                    "behaviorType"
+                  ]
                 },
                 "options": {
                   "dependencies": {

--- a/schema/wb-scenarios.schema.json
+++ b/schema/wb-scenarios.schema.json
@@ -232,7 +232,7 @@
                 }
               },
               "actionValue": {
-                "_format": "wb-action-value",
+                "_format": "wb-typed-value",
                 "propertyOrder": 3,
                 "title": "generalActionValueTitle",
                 "description": "outControls_actionValue_description",
@@ -1175,7 +1175,7 @@
                 }
               },
               "actionValue": {
-                "_format": "wb-action-value",
+                "_format": "wb-typed-value",
                 "propertyOrder": 3,
                 "title": "generalActionValueTitle",
                 "description": "outControls_actionValue_description",
@@ -1473,7 +1473,7 @@
                 }
               },
               "actionValue": {
-                "_format": "wb-action-value",
+                "_format": "wb-typed-value",
                 "propertyOrder": 3,
                 "title": "generalActionValueTitle",
                 "description": "outControls_actionValue_description",
@@ -1769,7 +1769,7 @@
                 }
               },
               "initValue": {
-                "_format": "wb-action-value",
+                "_format": "wb-typed-value",
                 "propertyOrder": 3,
                 "title": "periodicTimerInitValueTitle",
                 "default": "",
@@ -1786,7 +1786,7 @@
                 }
               },
               "reverseValue": {
-                "_format": "wb-action-value",
+                "_format": "wb-typed-value",
                 "propertyOrder": 4,
                 "title": "periodicTimerReverseValueTitle",
                 "default": "",

--- a/schema/wb-scenarios.schema.json
+++ b/schema/wb-scenarios.schema.json
@@ -231,7 +231,7 @@
                 }
               },
               "actionValue": {
-                "_format": "wb-typed-value",
+                "_format": "wb-dynamic-type",
                 "propertyOrder": 3,
                 "title": "generalActionValueTitle",
                 "description": "outControls_actionValue_description",
@@ -255,70 +255,13 @@
                     ]
                   }
                 }
-              },
-              "demoTableValue": {
-                "_format": "wb-typed-value",
-                "propertyOrder": 4,
-                "title": "Demo: in-table value (driven by out-of-table field)",
-                "default": "",
-                "options": {
-                  "dynamicType": {
-                    "source": "tableValueType",
-                    "map": {
-                      "color": ["wantColor"],
-                      "text": ["wantText"],
-                      "number": ["wantNumber"],
-                      "none": ["wantNone"]
-                    }
-                  }
-                }
               }
             },
             "required": ["control", "behaviorType"]
           }
-        },
-        "tableValueType": {
-          "type": "string",
-          "propertyOrder": 6,
-          "title": "Demo: type for in-table value",
-          "enum": ["wantColor", "wantText", "wantNumber", "wantNone"],
-          "default": "wantNumber",
-          "options": {
-            "grid_columns": 12,
-            "enum_titles": ["Color", "Text", "Number", "Hidden (none)"]
-          }
-        },
-        "demoMode": {
-          "type": "string",
-          "propertyOrder": 7,
-          "title": "Demo: out-of-table mode",
-          "enum": ["asColor", "asText", "asNumber", "asHidden"],
-          "default": "asNumber",
-          "options": {
-            "grid_columns": 12,
-            "enum_titles": ["Color", "Text", "Number", "Hidden (none)"]
-          }
-        },
-        "demoValue": {
-          "_format": "wb-typed-value",
-          "propertyOrder": 8,
-          "title": "Demo: out-of-table value",
-          "default": "",
-          "options": {
-            "grid_columns": 12,
-            "dynamicType": {
-              "source": "demoMode",
-              "map": {
-                "color": ["asColor"],
-                "text": ["asText"],
-                "number": ["asNumber"],
-                "none": ["asHidden"]
-              }
-            }
-          }
         }
       },
-      "required": ["scenarioType", "name", "inControls", "outControls", "tableValueType", "demoMode", "demoValue"]
+      "required": ["scenarioType", "name", "inControls", "outControls"]
     },
     "lightControl": {
       "title": "lightControlScenarioName",
@@ -1232,7 +1175,7 @@
                 }
               },
               "actionValue": {
-                "_format": "wb-typed-value",
+                "_format": "wb-dynamic-type",
                 "propertyOrder": 3,
                 "title": "generalActionValueTitle",
                 "description": "outControls_actionValue_description",
@@ -1531,7 +1474,7 @@
                 }
               },
               "actionValue": {
-                "_format": "wb-typed-value",
+                "_format": "wb-dynamic-type",
                 "propertyOrder": 3,
                 "title": "generalActionValueTitle",
                 "description": "outControls_actionValue_description",
@@ -1828,7 +1771,7 @@
                 }
               },
               "initValue": {
-                "_format": "wb-typed-value",
+                "_format": "wb-dynamic-type",
                 "propertyOrder": 3,
                 "title": "periodicTimerInitValueTitle",
                 "default": "",
@@ -1847,7 +1790,7 @@
                 }
               },
               "reverseValue": {
-                "_format": "wb-typed-value",
+                "_format": "wb-dynamic-type",
                 "propertyOrder": 4,
                 "title": "periodicTimerReverseValueTitle",
                 "default": "",

--- a/schema/wb-scenarios.schema.json
+++ b/schema/wb-scenarios.schema.json
@@ -181,7 +181,6 @@
             }
           },
           "items": {
-            "id": "urn:wb:devicesControlActionItem",
             "title": "generalActionObjTitle",
             "type": "object",
             "properties": {
@@ -237,13 +236,15 @@
                 "title": "generalActionValueTitle",
                 "description": "outControls_actionValue_description",
                 "default": "",
-                "watch": {
-                  "wbActionType": [
-                    "urn:wb:devicesControlActionItem",
-                    "behaviorType"
-                  ]
-                },
                 "options": {
+                  "dynamicType": {
+                    "source": "behaviorType",
+                    "map": {
+                      "color": ["setColor"],
+                      "text": ["setText"],
+                      "number": ["setValue", "increaseValueBy", "decreaseValueBy"]
+                    }
+                  },
                   "dependencies": {
                     "behaviorType": [
                       "setValue",
@@ -254,13 +255,70 @@
                     ]
                   }
                 }
+              },
+              "demoTableValue": {
+                "_format": "wb-typed-value",
+                "propertyOrder": 4,
+                "title": "Demo: in-table value (driven by out-of-table field)",
+                "default": "",
+                "options": {
+                  "dynamicType": {
+                    "source": "tableValueType",
+                    "map": {
+                      "color": ["wantColor"],
+                      "text": ["wantText"],
+                      "number": ["wantNumber"],
+                      "none": ["wantNone"]
+                    }
+                  }
+                }
               }
             },
             "required": ["control", "behaviorType"]
           }
+        },
+        "tableValueType": {
+          "type": "string",
+          "propertyOrder": 6,
+          "title": "Demo: type for in-table value",
+          "enum": ["wantColor", "wantText", "wantNumber", "wantNone"],
+          "default": "wantNumber",
+          "options": {
+            "grid_columns": 12,
+            "enum_titles": ["Color", "Text", "Number", "Hidden (none)"]
+          }
+        },
+        "demoMode": {
+          "type": "string",
+          "propertyOrder": 7,
+          "title": "Demo: out-of-table mode",
+          "enum": ["asColor", "asText", "asNumber", "asHidden"],
+          "default": "asNumber",
+          "options": {
+            "grid_columns": 12,
+            "enum_titles": ["Color", "Text", "Number", "Hidden (none)"]
+          }
+        },
+        "demoValue": {
+          "_format": "wb-typed-value",
+          "propertyOrder": 8,
+          "title": "Demo: out-of-table value",
+          "default": "",
+          "options": {
+            "grid_columns": 12,
+            "dynamicType": {
+              "source": "demoMode",
+              "map": {
+                "color": ["asColor"],
+                "text": ["asText"],
+                "number": ["asNumber"],
+                "none": ["asHidden"]
+              }
+            }
+          }
         }
       },
-      "required": ["scenarioType", "name", "inControls", "outControls"]
+      "required": ["scenarioType", "name", "inControls", "outControls", "tableValueType", "demoMode", "demoValue"]
     },
     "lightControl": {
       "title": "lightControlScenarioName",
@@ -1124,7 +1182,6 @@
             }
           },
           "items": {
-            "id": "urn:wb:scheduleActionItem",
             "title": "generalActionObjTitle",
             "type": "object",
             "properties": {
@@ -1180,13 +1237,15 @@
                 "title": "generalActionValueTitle",
                 "description": "outControls_actionValue_description",
                 "default": "",
-                "watch": {
-                  "wbActionType": [
-                    "urn:wb:scheduleActionItem",
-                    "behaviorType"
-                  ]
-                },
                 "options": {
+                  "dynamicType": {
+                    "source": "behaviorType",
+                    "map": {
+                      "color": ["setColor"],
+                      "text": ["setText"],
+                      "number": ["setValue", "increaseValueBy", "decreaseValueBy"]
+                    }
+                  },
                   "dependencies": {
                     "behaviorType": [
                       "setValue",
@@ -1422,7 +1481,6 @@
             }
           },
           "items": {
-            "id": "urn:wb:astronomicalTimerActionItem",
             "title": "generalActionObjTitle",
             "type": "object",
             "properties": {
@@ -1478,13 +1536,15 @@
                 "title": "generalActionValueTitle",
                 "description": "outControls_actionValue_description",
                 "default": "",
-                "watch": {
-                  "wbActionType": [
-                    "urn:wb:astronomicalTimerActionItem",
-                    "behaviorType"
-                  ]
-                },
                 "options": {
+                  "dynamicType": {
+                    "source": "behaviorType",
+                    "map": {
+                      "color": ["setColor"],
+                      "text": ["setText"],
+                      "number": ["setValue", "increaseValueBy", "decreaseValueBy"]
+                    }
+                  },
                   "dependencies": {
                     "behaviorType": [
                       "setValue",
@@ -1725,7 +1785,6 @@
             }
           },
           "items": {
-            "id": "urn:wb:periodicTimerActionItem",
             "title": "generalActionObjTitle",
             "type": "object",
             "properties": {
@@ -1773,13 +1832,15 @@
                 "propertyOrder": 3,
                 "title": "periodicTimerInitValueTitle",
                 "default": "",
-                "watch": {
-                  "wbActionType": [
-                    "urn:wb:periodicTimerActionItem",
-                    "behaviorType"
-                  ]
-                },
                 "options": {
+                  "dynamicType": {
+                    "source": "behaviorType",
+                    "map": {
+                      "color": ["setColor"],
+                      "text": ["setText"],
+                      "number": ["setValue"]
+                    }
+                  },
                   "dependencies": {
                     "behaviorType": ["setValue", "setText", "setColor"]
                   }
@@ -1790,13 +1851,15 @@
                 "propertyOrder": 4,
                 "title": "periodicTimerReverseValueTitle",
                 "default": "",
-                "watch": {
-                  "wbActionType": [
-                    "urn:wb:periodicTimerActionItem",
-                    "behaviorType"
-                  ]
-                },
                 "options": {
+                  "dynamicType": {
+                    "source": "behaviorType",
+                    "map": {
+                      "color": ["setColor"],
+                      "text": ["setText"],
+                      "number": ["setValue"]
+                    }
+                  },
                   "dependencies": {
                     "behaviorType": ["setValue", "setText", "setColor"]
                   }

--- a/schema/wb-scenarios.schema.json
+++ b/schema/wb-scenarios.schema.json
@@ -181,6 +181,7 @@
             }
           },
           "items": {
+            "id": "devicesControlActionItem",
             "title": "generalActionObjTitle",
             "type": "object",
             "properties": {
@@ -212,7 +213,9 @@
                   "setDisable",
                   "setValue",
                   "increaseValueBy",
-                  "decreaseValueBy"
+                  "decreaseValueBy",
+                  "setText",
+                  "setColor"
                 ],
                 "default": "setDisable",
                 "options": {
@@ -222,22 +225,32 @@
                     "Disable (switch)",
                     "generalEnumSetValue",
                     "Increase Value By",
-                    "Decrease Value By"
+                    "Decrease Value By",
+                    "generalEnumSetText",
+                    "generalEnumSetColor"
                   ]
                 }
               },
               "actionValue": {
-                "type": "number",
+                "_format": "wb-action-value",
                 "propertyOrder": 3,
                 "title": "generalActionValueTitle",
                 "description": "outControls_actionValue_description",
-                "default": 0,
+                "default": "",
+                "watch": {
+                  "wbActionType": [
+                    "devicesControlActionItem",
+                    "behaviorType"
+                  ]
+                },
                 "options": {
                   "dependencies": {
                     "behaviorType": [
                       "setValue",
                       "increaseValueBy",
-                      "decreaseValueBy"
+                      "decreaseValueBy",
+                      "setText",
+                      "setColor"
                     ]
                   }
                 }
@@ -1111,6 +1124,7 @@
             }
           },
           "items": {
+            "id": "scheduleActionItem",
             "title": "generalActionObjTitle",
             "type": "object",
             "properties": {
@@ -1142,7 +1156,9 @@
                   "setDisable",
                   "setValue",
                   "increaseValueBy",
-                  "decreaseValueBy"
+                  "decreaseValueBy",
+                  "setText",
+                  "setColor"
                 ],
                 "default": "setDisable",
                 "options": {
@@ -1152,22 +1168,29 @@
                     "Disable (switch)",
                     "generalEnumSetValue",
                     "Increase Value By",
-                    "Decrease Value By"
+                    "Decrease Value By",
+                    "generalEnumSetText",
+                    "generalEnumSetColor"
                   ]
                 }
               },
               "actionValue": {
-                "type": "number",
+                "_format": "wb-action-value",
                 "propertyOrder": 3,
                 "title": "generalActionValueTitle",
                 "description": "outControls_actionValue_description",
-                "default": 0,
+                "default": "",
+                "watch": {
+                  "wbActionType": ["scheduleActionItem", "behaviorType"]
+                },
                 "options": {
                   "dependencies": {
                     "behaviorType": [
                       "setValue",
                       "increaseValueBy",
-                      "decreaseValueBy"
+                      "decreaseValueBy",
+                      "setText",
+                      "setColor"
                     ]
                   }
                 }
@@ -1686,6 +1709,7 @@
             }
           },
           "items": {
+            "id": "periodicTimerActionItem",
             "title": "generalActionObjTitle",
             "type": "object",
             "properties": {
@@ -1710,35 +1734,49 @@
                 "type": "string",
                 "propertyOrder": 2,
                 "title": "outControls_behaviorType_title",
-                "enum": ["setEnable", "setDisable", "setValue"],
+                "enum": [
+                  "setEnable",
+                  "setDisable",
+                  "setValue",
+                  "setText",
+                  "setColor"
+                ],
                 "default": "setEnable",
                 "options": {
                   "enum_titles": [
                     "Enable (switch)",
                     "Disable (switch)",
-                    "generalEnumSetValue"
+                    "generalEnumSetValue",
+                    "generalEnumSetText",
+                    "generalEnumSetColor"
                   ]
                 }
               },
               "initValue": {
-                "type": "number",
+                "_format": "wb-action-value",
                 "propertyOrder": 3,
                 "title": "periodicTimerInitValueTitle",
-                "default": 0,
+                "default": "",
+                "watch": {
+                  "wbActionType": ["periodicTimerActionItem", "behaviorType"]
+                },
                 "options": {
                   "dependencies": {
-                    "behaviorType": ["setValue"]
+                    "behaviorType": ["setValue", "setText", "setColor"]
                   }
                 }
               },
               "reverseValue": {
-                "type": "number",
+                "_format": "wb-action-value",
                 "propertyOrder": 4,
                 "title": "periodicTimerReverseValueTitle",
-                "default": 0,
+                "default": "",
+                "watch": {
+                  "wbActionType": ["periodicTimerActionItem", "behaviorType"]
+                },
                 "options": {
                   "dependencies": {
-                    "behaviorType": ["setValue"]
+                    "behaviorType": ["setValue", "setText", "setColor"]
                   }
                 }
               }
@@ -2214,9 +2252,13 @@
       "generalMqttTopicNamePlaceholder": "Device/Control",
       "generalBehaviorTypeTitle": "Trigger logic",
       "generalActionValueTitle": "Value",
+      "generalTextValueTitle": "Text value",
+      "generalColorValueTitle": "Color",
       "generalErrorRegexpPatternMessageGeneralType": "Value must be valid",
       "generalErrorRegexpPatternMessageMqttTopicName": "Does not match the format <device>/<control>",
       "generalEnumSetValue": "Set Value",
+      "generalEnumSetText": "Set Text",
+      "generalEnumSetColor": "Set Color",
       "generalSensorArrTitle": "Elements list",
       "generalActionsTitle": "Actions",
       "generalActionObjTitle": "Action",
@@ -2400,9 +2442,13 @@
       "generalMqttTopicNamePlaceholder": "Устройство/Контрол",
       "generalBehaviorTypeTitle": "Логика срабатывания",
       "generalActionValueTitle": "Значение",
+      "generalTextValueTitle": "Текстовое значение",
+      "generalColorValueTitle": "Цвет",
       "generalErrorRegexpPatternMessageGeneralType": "Значение должно быть корректным",
       "generalErrorRegexpPatternMessageMqttTopicName": "Не соответствует формату <устройство>/<контрол>",
       "generalEnumSetValue": "Установить значение",
+      "generalEnumSetText": "Установить текст",
+      "generalEnumSetColor": "Установить цвет",
       "generalSensorArrTitle": "Список элементов",
       "generalActionsTitle": "Действия",
       "generalActionObjTitle": "Действие",

--- a/schema/wb-scenarios.schema.json
+++ b/schema/wb-scenarios.schema.json
@@ -235,14 +235,17 @@
                 "propertyOrder": 3,
                 "title": "generalActionValueTitle",
                 "description": "outControls_actionValue_description",
-                "default": "",
                 "options": {
                   "dynamicType": {
                     "source": "behaviorType",
                     "map": {
                       "color": ["setColor"],
                       "text": ["setText"],
-                      "number": ["setValue", "increaseValueBy", "decreaseValueBy"]
+                      "number": [
+                        "setValue",
+                        "increaseValueBy",
+                        "decreaseValueBy"
+                      ]
                     }
                   },
                   "dependencies": {
@@ -1179,14 +1182,17 @@
                 "propertyOrder": 3,
                 "title": "generalActionValueTitle",
                 "description": "outControls_actionValue_description",
-                "default": "",
                 "options": {
                   "dynamicType": {
                     "source": "behaviorType",
                     "map": {
                       "color": ["setColor"],
                       "text": ["setText"],
-                      "number": ["setValue", "increaseValueBy", "decreaseValueBy"]
+                      "number": [
+                        "setValue",
+                        "increaseValueBy",
+                        "decreaseValueBy"
+                      ]
                     }
                   },
                   "dependencies": {
@@ -1478,14 +1484,17 @@
                 "propertyOrder": 3,
                 "title": "generalActionValueTitle",
                 "description": "outControls_actionValue_description",
-                "default": "",
                 "options": {
                   "dynamicType": {
                     "source": "behaviorType",
                     "map": {
                       "color": ["setColor"],
                       "text": ["setText"],
-                      "number": ["setValue", "increaseValueBy", "decreaseValueBy"]
+                      "number": [
+                        "setValue",
+                        "increaseValueBy",
+                        "decreaseValueBy"
+                      ]
                     }
                   },
                   "dependencies": {
@@ -1774,7 +1783,6 @@
                 "_format": "wb-dynamic-type",
                 "propertyOrder": 3,
                 "title": "periodicTimerInitValueTitle",
-                "default": "",
                 "options": {
                   "dynamicType": {
                     "source": "behaviorType",
@@ -1793,7 +1801,6 @@
                 "_format": "wb-dynamic-type",
                 "propertyOrder": 4,
                 "title": "periodicTimerReverseValueTitle",
-                "default": "",
                 "options": {
                   "dynamicType": {
                     "source": "behaviorType",

--- a/src/table-handling-actions.mod.js
+++ b/src/table-handling-actions.mod.js
@@ -42,7 +42,7 @@ function toggle(actualValue, actionValue) {
  * @returns {number} Returns new control value
  */
 function setValue(actualValue, actionValue) {
-  var newCtrlValue = actionValue;
+  var newCtrlValue = Number(actionValue);
   return newCtrlValue;
 }
 
@@ -53,7 +53,7 @@ function setValue(actualValue, actionValue) {
  * @returns {number} Returns new control value
  */
 function increaseValueBy(actualValue, actionValue) {
-  var newCtrlValue = actualValue + actionValue;
+  var newCtrlValue = actualValue + Number(actionValue);
   return newCtrlValue;
 }
 
@@ -64,8 +64,35 @@ function increaseValueBy(actualValue, actionValue) {
  * @returns {number} Returns new control value
  */
 function decreaseValueBy(actualValue, actionValue) {
-  var newCtrlValue = actualValue - actionValue;
+  var newCtrlValue = actualValue - Number(actionValue);
   return newCtrlValue;
+}
+
+/**
+ * Action to set a text control value to actionValue
+ * @param {string} actualValue - Current state of the control
+ * @param {string} actionValue - Text set by user
+ * @returns {string} Returns new control value
+ */
+function setText(actualValue, actionValue) {
+  var newCtrlValue = actionValue;
+  return newCtrlValue;
+}
+
+/**
+ * Action to set an rgb control to actionValue color
+ * The color picker stores a hex string (#rrggbb), but an rgb
+ * control expects the "R;G;B" decimal format
+ * @param {string} actualValue - Current state of the control
+ * @param {string} actionValue - Hex color set by user (e.g. "#ff8040")
+ * @returns {string} Color in "R;G;B" format (e.g. "255;128;64")
+ */
+function setColor(actualValue, actionValue) {
+  var hex = String(actionValue).replace('#', '');
+  var r = parseInt(hex.substr(0, 2), 16);
+  var g = parseInt(hex.substr(2, 2), 16);
+  var b = parseInt(hex.substr(4, 2), 16);
+  return r + ';' + g + ';' + b;
 }
 
 /**
@@ -98,6 +125,14 @@ var actionsTable = {
   decreaseValueBy: {
     reqCtrlTypes: ['value', 'range'],
     handler: decreaseValueBy,
+  },
+  setText: {
+    reqCtrlTypes: ['text'],
+    handler: setText,
+  },
+  setColor: {
+    reqCtrlTypes: ['rgb'],
+    handler: setColor,
   },
 };
 

--- a/src/table-handling-actions.mod.js
+++ b/src/table-handling-actions.mod.js
@@ -81,8 +81,9 @@ function setText(actualValue, actionValue) {
 
 /**
  * Action to set an rgb control to actionValue color
- * The color picker stores a hex string (#rrggbb), but an rgb
- * control expects the "R;G;B" decimal format
+ * The browser's native color input (used by the wb-dynamic-type widget)
+ * always yields a hex string (#rrggbb); a WB rgb control expects the
+ * "R;G;B" decimal format, so we convert here at publish time
  * @param {string} actualValue - Current state of the control
  * @param {string} actionValue - Hex color set by user (e.g. "#ff8040")
  * @returns {string} Color in "R;G;B" format (e.g. "255;128;64")


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Выходные действия сценариев умели задавать только число и включение/выключение. Добавляем во все сценарии с выходами два действия, «Установить цвет» (палитра) и «Установить текст». Покрыты все четыре типа сценариев с выходами — Автоматизация, Расписание, Астро-таймер, Периодический таймер.

[PR с добавлением кастомного редактора в homeui](https://github.com/wirenboard/homeui/pull/1109)

Пример сценария Автоматизация:
<img width="1703" height="741" alt="image" src="https://github.com/user-attachments/assets/0673a817-62d0-4f83-a682-752ace2c33e4" />

Пример сценария Расписание:
<img width="1697" height="721" alt="image" src="https://github.com/user-attachments/assets/bc290532-f8d0-44fa-9adb-631effe730b2" />

Пример сценария Астро-таймера:
<img width="1706" height="901" alt="image" src="https://github.com/user-attachments/assets/7b17eda6-3c41-4ff1-b367-2c86ef07351b" />

Пример сценария Периодический таймер:
<img width="1702" height="908" alt="image" src="https://github.com/user-attachments/assets/dc667a50-8ade-4de2-85ee-d71d0194b1db" />

___________________________________
**Что поменялось для пользователей:**

Вместо отдельных полей под каждый тип теперь одно поле «Значение», которое подстраивается под выбранное действие. Число для «Установить значение», текстовое поле для «Установить текст», квадратик-палитра для «Установить цвет». Старые сценарии с числовыми значениями продолжают работать без изменений и без миграции конфигов.

___________________________________
**Как проверял/а:**

Проверял на контроллере wb8 (trixie).

Существующий числовой конфиг открывается на новой схеме без миграции, сохранённые значения остаются на месте. Создал по сценарию каждого типа и проверил все три действия. Поле «Значение» подстраивается под выбранное действие (число, текст, палитра). Цвет публикуется в `rgb`-контрол в формате `R;G;B`, текст и число доходят до своих контролов.

Отдельно проверил установку пакетов.
