### PR TITLE
feat: rename wb-dynamic-type options keys in schema INT-1155

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
 wb-scenarios (1.9.8) stable; urgency=medium
 
-  * schema: rename wb-dynamic-type options keys to sourceField and typeByValue
+  * schema: rename wb-dynamic-type options keys
 
- -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Tue, 07 Jul 2026 12:40:00 +0300
+ -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Thu, 09 Jul 2026 16:53:00 +0300
 
 wb-scenarios (1.9.7) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-scenarios (1.9.8) stable; urgency=medium
+
+  * schema: rename wb-dynamic-type options keys to sourceField and typeByValue
+
+ -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Tue, 07 Jul 2026 12:40:00 +0300
+
 wb-scenarios (1.9.7) stable; urgency=medium
 
   * Add Set Color and Set Text output actions to light-control

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Architecture: all
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          wb-rules (>= 2.20.0~~),
-         wb-mqtt-homeui (>= 2.237.8~~)
+         wb-mqtt-homeui (>= 2.237.9~~)
 Description: Scenarios for Wiren Board
  This package provides ready-to-use scripts
  to connect devices and link them together more quickly.

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Architecture: all
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          wb-rules (>= 2.20.0~~),
-         wb-mqtt-homeui (>= 2.236.1~~)
+         wb-mqtt-homeui (>= 2.237.8~~)
 Description: Scenarios for Wiren Board
  This package provides ready-to-use scripts
  to connect devices and link them together more quickly.

--- a/schema/wb-scenarios.schema.json
+++ b/schema/wb-scenarios.schema.json
@@ -237,15 +237,19 @@
                 "description": "outControls_actionValue_description",
                 "options": {
                   "dynamicType": {
-                    "source": "behaviorType",
-                    "map": {
-                      "color": ["setColor"],
-                      "text": ["setText"],
-                      "number": [
-                        "setValue",
-                        "increaseValueBy",
-                        "decreaseValueBy"
-                      ]
+                    "sourceField": "behaviorType",
+                    "typeByValue": {
+                      "setColor": "color",
+                      "setText": "text",
+                      "setValue": "number",
+                      "increaseValueBy": "number",
+                      "decreaseValueBy": "number"
+                    },
+                    "defaultType": "number",
+                    "defaultValueByType": {
+                      "color": "#ffffff",
+                      "number": 0,
+                      "text": ""
                     }
                   },
                   "dependencies": {
@@ -407,11 +411,17 @@
                     "title": "lightControlOnValueTitle",
                     "options": {
                       "dynamicType": {
-                        "source": "behaviorType",
-                        "map": {
-                          "color": ["setColor"],
-                          "text": ["setText"],
-                          "number": ["setValueNumericInput"]
+                        "sourceField": "behaviorType",
+                        "typeByValue": {
+                          "setColor": "color",
+                          "setText": "text",
+                          "setValueNumericInput": "number"
+                        },
+                        "defaultType": "number",
+                        "defaultValueByType": {
+                          "color": "#ffffff",
+                          "number": 0,
+                          "text": ""
                         }
                       },
                       "dependencies": {
@@ -429,11 +439,17 @@
                     "title": "lightControlOffValueTitle",
                     "options": {
                       "dynamicType": {
-                        "source": "behaviorType",
-                        "map": {
-                          "color": ["setColor"],
-                          "text": ["setText"],
-                          "number": ["setValueNumericInput"]
+                        "sourceField": "behaviorType",
+                        "typeByValue": {
+                          "setColor": "color",
+                          "setText": "text",
+                          "setValueNumericInput": "number"
+                        },
+                        "defaultType": "number",
+                        "defaultValueByType": {
+                          "color": "#ffffff",
+                          "number": 0,
+                          "text": ""
                         }
                       },
                       "dependencies": {
@@ -1225,15 +1241,19 @@
                 "description": "outControls_actionValue_description",
                 "options": {
                   "dynamicType": {
-                    "source": "behaviorType",
-                    "map": {
-                      "color": ["setColor"],
-                      "text": ["setText"],
-                      "number": [
-                        "setValue",
-                        "increaseValueBy",
-                        "decreaseValueBy"
-                      ]
+                    "sourceField": "behaviorType",
+                    "typeByValue": {
+                      "setColor": "color",
+                      "setText": "text",
+                      "setValue": "number",
+                      "increaseValueBy": "number",
+                      "decreaseValueBy": "number"
+                    },
+                    "defaultType": "number",
+                    "defaultValueByType": {
+                      "color": "#ffffff",
+                      "number": 0,
+                      "text": ""
                     }
                   },
                   "dependencies": {
@@ -1527,15 +1547,19 @@
                 "description": "outControls_actionValue_description",
                 "options": {
                   "dynamicType": {
-                    "source": "behaviorType",
-                    "map": {
-                      "color": ["setColor"],
-                      "text": ["setText"],
-                      "number": [
-                        "setValue",
-                        "increaseValueBy",
-                        "decreaseValueBy"
-                      ]
+                    "sourceField": "behaviorType",
+                    "typeByValue": {
+                      "setColor": "color",
+                      "setText": "text",
+                      "setValue": "number",
+                      "increaseValueBy": "number",
+                      "decreaseValueBy": "number"
+                    },
+                    "defaultType": "number",
+                    "defaultValueByType": {
+                      "color": "#ffffff",
+                      "number": 0,
+                      "text": ""
                     }
                   },
                   "dependencies": {
@@ -1826,11 +1850,17 @@
                 "title": "periodicTimerInitValueTitle",
                 "options": {
                   "dynamicType": {
-                    "source": "behaviorType",
-                    "map": {
-                      "color": ["setColor"],
-                      "text": ["setText"],
-                      "number": ["setValue"]
+                    "sourceField": "behaviorType",
+                    "typeByValue": {
+                      "setColor": "color",
+                      "setText": "text",
+                      "setValue": "number"
+                    },
+                    "defaultType": "number",
+                    "defaultValueByType": {
+                      "color": "#ffffff",
+                      "number": 0,
+                      "text": ""
                     }
                   },
                   "dependencies": {
@@ -1844,11 +1874,17 @@
                 "title": "periodicTimerReverseValueTitle",
                 "options": {
                   "dynamicType": {
-                    "source": "behaviorType",
-                    "map": {
-                      "color": ["setColor"],
-                      "text": ["setText"],
-                      "number": ["setValue"]
+                    "sourceField": "behaviorType",
+                    "typeByValue": {
+                      "setColor": "color",
+                      "setText": "text",
+                      "setValue": "number"
+                    },
+                    "defaultType": "number",
+                    "defaultValueByType": {
+                      "color": "#ffffff",
+                      "number": 0,
+                      "text": ""
                     }
                   },
                   "dependencies": {


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Приводим схему сценариев к новому контракту виджета [`wb-dynamic-type` из homeui](https://github.com/wirenboard/homeui/pull/1152). В homeui причесали ключи `options.dynamicType` — `source` стал `sourceField`, а `map` стал `typeByValue` с перевёрнутым форматом `значение источника → тип поля`. Здесь переводим все семь полей схемы на эти имена, чтобы после обновления homeui поле «Значение» продолжало морфиться в число, текст или палитру по значению `behaviorType`.

Ключи авторские, живут только в этой схеме, в пользовательских конфигах сценариев их нет. Миграция данных не нужна, сохранённая форма конфига не меняется.

___________________________________
**Что поменялось для пользователей:**

Видимых изменений для пользователя нет, поведение виджета то же. Правки затрагивают только внутренний контракт схемы.

- Семь полей `wb-dynamic-type` переведены с `source`/`map` на `sourceField`/`typeByValue` — `outControls.actionValue` в devicesControl, schedule и astronomicalTimer, `lightControl.onValue` и `resetValue`, `periodicTimer.initValue` и `reverseValue`.
- Формат карты перевёрнут на `значение → тип`, например `{ "setColor": "color", "setText": "text", "setValue": "number" }`. Одно значение однозначно задаёт один тип.
- `defaultType` и `defaultValueByType` прописаны в каждом блоке явно (`defaultType: "number"`, `defaultValueByType: { color: "#ffffff", number: 0, text: "" }`). Значения совпадают со встроенными дефолтами виджета, поведение прежнее, но читателю схемы всё видно без знания внутренностей виджета.
- `Depends` на `wb-mqtt-homeui` поднята.

___________________________________
**Как проверял/а:**

- JSON схемы валиден, prettier без замечаний. Все семь блоков переведены, ключей `source`/`map` в схеме не осталось.
- Сквозную проверку на контроллере делаем после установки homeui  — поле «Значение» морфится по `behaviorType`, сохранённые значения выживают при переоткрытии сценария.

---

**Порядок мержа:** этот PR завязан по `Depends` на homeui. Мержить и выкладывать его нужно ПОСЛЕ того, как homeui с новым контрактом (`typeByValue`/`sourceField`) влит и версия зафиксирована. Если версия homeui на мерже изменится — поправить число в `Depends` и в этой заметке.