### PR TITLE
fix: implicit globals and JSDoc inaccuracies found by wb-rules checkJs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-scenarios (1.10.2) stable; urgency=medium
+
+  * Declare implicit globals (ok in light-control, id in translit) found by wb-rules checkJs
+  * Fix JSDoc inaccuracies found by wb-rules checkJs, no runtime changes
+
+ -- Evgeny Boger <boger@wirenboard.com>  Wed, 19 Aug 2026 12:36:09 +0300
+
 wb-scenarios (1.10.1) stable; urgency=medium
 
   * Merge the two action tables into table-handling-actions.mod.js

--- a/develop/scenario-init-link-in-to-out.mod.js
+++ b/develop/scenario-init-link-in-to-out.mod.js
@@ -24,7 +24,7 @@ var log = new Logger('WBSC-' + CFG.scenarioTypeStr + '-init');
 
 /**
  * Initialize scenario using specified settings
- * @param {object} scenarioCfg - Scenario object containing settings
+ * @param {Object} scenarioCfg - Scenario object containing settings
  * @returns {void}
  */
 function initializeScenario(scenarioCfg) {

--- a/scenarios/astronomical-timer/astronomical-timer.mod.js
+++ b/scenarios/astronomical-timer/astronomical-timer.mod.js
@@ -335,7 +335,6 @@ AstronomicalTimerScenario.prototype.validateCfg = function (cfg) {
  * Adds required custom controls cells to the virtual device
  * @param {AstronomicalTimerScenario} self - Reference to the AstronomicalTimerScenario instance
  * @param {AstronomicalTimerConfig} cfg - Configuration object
- * @returns {boolean} True if initialization succeeded
  */
 function addCustomControlsToVirtualDevice(self, cfg) {
   log.debug('Start add custom controls to virtual device');

--- a/scenarios/astronomical-timer/scenario-init-astronomical-timer.mod.js
+++ b/scenarios/astronomical-timer/scenario-init-astronomical-timer.mod.js
@@ -24,7 +24,7 @@ var log = new Logger('WBSC-' + CFG.scenarioTypeStr + '-init');
 
 /**
  * Initializes a scenario using the specified settings
- * @param {object} scenarioCfg - The scenario object containing the settings
+ * @param {Object} scenarioCfg - The scenario object containing the settings
  * @returns {void}
  */
 function initializeScenario(scenarioCfg) {

--- a/scenarios/channel-map/scenario-init-channel-map.mod.js
+++ b/scenarios/channel-map/scenario-init-channel-map.mod.js
@@ -26,7 +26,7 @@ var log = new Logger('WBSC-' + CFG.scenarioTypeStr + '-init');
 
 /**
  * Initializes a scenario using the specified settings
- * @param {object} scenarioCfg - The scenario object containing the settings
+ * @param {Object} scenarioCfg - The scenario object containing the settings
  * @returns {void}
  */
 function initializeScenario(scenarioCfg) {

--- a/scenarios/devices-control/scenario-init-devices-control.mod.js
+++ b/scenarios/devices-control/scenario-init-devices-control.mod.js
@@ -27,7 +27,7 @@ var log = new Logger('WBSC-' + CFG.scenarioTypeStr + '-init');
 
 /**
  * Initializes a scenario using the specified settings
- * @param {object} scenarioCfg - The scenario object containing the settings
+ * @param {Object} scenarioCfg - The scenario object containing the settings
  * @returns {void}
  */
 function initializeScenario(scenarioCfg) {

--- a/scenarios/light-control/light-control.mod.js
+++ b/scenarios/light-control/light-control.mod.js
@@ -1352,7 +1352,7 @@ LightControlScenario.prototype.initSpecific = function (deviceTitle, cfg) {
   if (cfg.isDebugEnabled === true) {
     log.debug('Scenario debug enabled - add extra controls to VD');
     var self = this;
-    ok = addAllLinkedDevicesToVd(self, cfg);
+    var ok = addAllLinkedDevicesToVd(self, cfg);
     if (!ok) return false;
   }
 

--- a/scenarios/light-control/light-control.mod.js
+++ b/scenarios/light-control/light-control.mod.js
@@ -582,6 +582,13 @@ function setValueAllDevicesByBehavior(actionControlsArr, state) {
  * @property {string} behaviorType - Sensor behavior type
  *   - whenEnabled
  *   - whenDisabled
+ *   - whileValueHigherThanThreshold (motion sensors, uses actionValue)
+ * @property {any} [actionValue] - Threshold for whileValueHigherThanThreshold;
+ *   for light devices - the value applied by the action
+ * @property {any} [resolvedOnValue] - Light devices only: value published on
+ *   "light on", precomputed by precomputeLightDeviceTargets()
+ * @property {any} [resolvedOffValue] - Light devices only: value published on
+ *   "light off", precomputed by precomputeLightDeviceTargets()
  * @property {string} [description] - Optional description of the sensor
  */
 

--- a/scenarios/light-control/scenario-init-light-control.mod.js
+++ b/scenarios/light-control/scenario-init-light-control.mod.js
@@ -27,7 +27,7 @@ var log = new Logger('WBSC-' + CFG.scenarioTypeStr + '-init');
 
 /**
  * Initializes a scenario using the specified settings
- * @param {object} scenarioCfg - The scenario object containing the settings
+ * @param {Object} scenarioCfg - The scenario object containing the settings
  * @returns {void}
  */
 function initializeScenario(scenarioCfg) {

--- a/scenarios/periodic-timer/scenario-init-periodic-timer.mod.js
+++ b/scenarios/periodic-timer/scenario-init-periodic-timer.mod.js
@@ -27,7 +27,7 @@ var log = new Logger('WBSC-' + CFG.scenarioTypeStr + '-init');
 
 /**
  * Initializes a scenario using the specified settings
- * @param {object} scenarioCfg - The scenario object containing the settings
+ * @param {Object} scenarioCfg - The scenario object containing the settings
  * @returns {void}
  */
 function initializeScenario(scenarioCfg) {

--- a/scenarios/schedule/scenario-init-schedule.mod.js
+++ b/scenarios/schedule/scenario-init-schedule.mod.js
@@ -23,7 +23,7 @@ var log = new Logger('WBSC-' + CFG.scenarioTypeStr + '-init');
 
 /**
  * Initializes a scenario using the specified settings
- * @param {object} scenarioCfg - The scenario object containing the settings
+ * @param {Object} scenarioCfg - The scenario object containing the settings
  * @returns {void}
  */
 function initializeScenario(scenarioCfg) {

--- a/scenarios/schedule/schedule.mod.js
+++ b/scenarios/schedule/schedule.mod.js
@@ -32,6 +32,12 @@ var VALID_DAYS = constants.VALID_DAYS;
  * @property {string} [idPrefix] - Optional prefix for scenario identification
  *   If not provided, it will be generated from the scenario name
  * @property {string} scheduleTime - Time to trigger in HH:MM format
+ * @property {number} [hours] - Trigger hour (0-23), filled in from
+ *   scheduleTime by parseScheduleTime() during validation
+ * @property {number} [minutes] - Trigger minute (0-59), filled in from
+ *   scheduleTime by parseScheduleTime() during validation
+ * @property {number} [seconds] - Trigger second (always 0), filled in
+ *   by parseScheduleTime() during validation
  * @property {Array<string>} scheduleDaysOfWeek - Array of selected weekdays
  *   Valid values: "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"
  * @property {DurationObj} duration - Turn-off delay.
@@ -613,7 +619,6 @@ function scheduleHandler(self, cfg) {
  * Adds required custom controls cells to the virtual device
  * @param {ScheduleScenario} self - Reference to the ScheduleScenario instance
  * @param {ScheduleConfig} cfg - Configuration object
- * @returns {boolean} True if initialization succeeded
  */
 function addCustomControlsToVirtualDevice(self, cfg) {
   log.debug('Start add custom controls to virtual device');

--- a/scenarios/thermostat/scenario-init-thermostat.mod.js
+++ b/scenarios/thermostat/scenario-init-thermostat.mod.js
@@ -27,7 +27,7 @@ var log = new Logger('WBSC-' + CFG.scenarioTypeStr + '-init');
 
 /**
  * Initializes a scenario using the specified settings
- * @param {object} scenarioCfg - The scenario object containing the settings
+ * @param {Object} scenarioCfg - The scenario object containing the settings
  * @returns {void}
  */
 function initializeScenario(scenarioCfg) {

--- a/scenarios/thermostat/thermostat.mod.js
+++ b/scenarios/thermostat/thermostat.mod.js
@@ -66,9 +66,7 @@ var thermostatActionsTable = {
  * PID mode (controlMode === 'pid'):
  * @property {Object} pidSettings - PID settings object
  * @property {number} pidSettings.deadBand - Dead band around setpoint (°C)
- * @property {number} pidSettings.kp - Proportional gain
- * @property {number} pidSettings.ki - Integral gain
- * @property {number} pidSettings.kd - Derivative gain
+ * @property {PidCoefficients} pidSettings.pidCoefficients - PID gains (kp, ki, kd)
  * @property {number} pidSettings.pwmPeriodSec - PWM cycle duration (seconds)
  * @property {number} pidSettings.pidRecalcCycles - Recompute PID every N cycles
  * @property {number} pidSettings.minOnTimeSec - Minimum actuator ON time (s)
@@ -383,6 +381,7 @@ ThermostatScenario.prototype.validateCfg = function (cfg) {
  * @param {number} initialTemp - Initial value for the target temperature
  */
 function addCustomControlsToVirtualDevice(self, cfg, initialTemp) {
+  /** @type {ControlOptions} */
   var controlCfg = {
     title: {
       en: 'Temperature Setpoint',
@@ -791,7 +790,7 @@ function tryClearReadonly(vdCtrlEnable, cfg) {
  *     Example: `vdCtrlCurTemp = vdObj.getControl('ctrlID')`
  * @param {Object} vdCtrlEnable - Control "Enable rules" in scenario virtual dev
  * @param {ThermostatConfig} cfg - Configuration parameters
- * @returns {boolean} True if rule created successfully
+ * @returns {RuleId} ID of the created rule (falsy if creation failed)
  */
 function createErrChangeRule(
   self,

--- a/scenarios/thermostat/thermostat.mod.js
+++ b/scenarios/thermostat/thermostat.mod.js
@@ -790,7 +790,7 @@ function tryClearReadonly(vdCtrlEnable, cfg) {
  *     Example: `vdCtrlCurTemp = vdObj.getControl('ctrlID')`
  * @param {Object} vdCtrlEnable - Control "Enable rules" in scenario virtual dev
  * @param {ThermostatConfig} cfg - Configuration parameters
- * @returns {RuleId} ID of the created rule (falsy if creation failed)
+ * @returns {RuleId} ID of the created rule
  */
 function createErrChangeRule(
   self,

--- a/src/logger.mod.js
+++ b/src/logger.mod.js
@@ -12,7 +12,7 @@
 
 /**
  * Creates a copy of an array or transforms a Arguments collection into an arr
- * @param {Array|Arguments} srcArr Source array or Arguments collection
+ * @param {Array|IArguments} srcArr Source array or Arguments collection
  * @return {Array} A new array with the same elements
  */
 function copyArray(srcArr) {
@@ -40,7 +40,7 @@ function Logger(label) {
 /**
  * Logs a message if the logger is enabled
  * @param {Function} logMethod The log function to call (log.debug, etc.)
- * @param {Arguments} logArgs Arguments for call global log.*** func
+ * @param {IArguments} logArgs Arguments for call global log.*** func
  * @private
  */
 

--- a/src/pid-engine.mod.js
+++ b/src/pid-engine.mod.js
@@ -140,14 +140,13 @@ PidEngine.prototype.reset = function () {
 
 /**
  * Get current PID state for debugging/logging
- * @returns {Object} PID components and output
- * @returns {number} returns.p - Last P component
- * @returns {number} returns.i - Last I component
- *     (= current integral value)
- * @returns {number} returns.d - Last D component
- * @returns {number} returns.integral - Accumulated
- *     integral value
- * @returns {number} returns.output - Last output
+ * @returns {{p: number, i: number, d: number, integral: number, output: number}}
+ *     PID components and output:
+ *     - p: Last P component
+ *     - i: Last I component (= current integral value)
+ *     - d: Last D component
+ *     - integral: Accumulated integral value
+ *     - output: Last output
  */
 PidEngine.prototype.getState = function () {
   return {

--- a/src/translit.mod.js
+++ b/src/translit.mod.js
@@ -65,7 +65,7 @@ function replaceChar(char) {
  *     with valid characters only
  */
 function translit(input) {
-  id = input
+  var id = input
     .toLowerCase()
     .split('')
     .map(replaceChar) // Replaces non-Latin symbols to latin char

--- a/src/virtual-device-helpers.mod.js
+++ b/src/virtual-device-helpers.mod.js
@@ -52,10 +52,10 @@ function isControlExists(controlName) {
  * Добавляет RO (read-only) связанный контрол к виртуальному девайсу.
  * Используется для отображения статуса других датчиков в списке виртуального устройства.
  *
- * @param {Object} srcMqttControl - Строка MQTT control ('deviceName/cellName')
+ * @param {string} srcMqttControl - Строка MQTT control ('deviceName/cellName')
  * @param {Object} vDevObj - Объект виртуального девайса (как результат defineVirtualDevice)
+ * @param {string} vDevName - Имя виртуального девайса (используется в имени правила и топика)
  * @param {string} cellBaseName - Название базовой ячейки (например 'motion_sensor_0')
- * @param {string} cellType - Тип ячейки (например 'value')
  * @param {string} titlePrefix - Префикс для заголовка (например 'Motion:' или 'Opening:')
  * @returns {boolean} Возвращает true если все ок
  */
@@ -135,7 +135,7 @@ function addAlarm(vDevObj, cellBaseName, cellTitleRu, cellTitleEn) {
 
 /**
  * Toggles rules based on the provided value
- * @param {Array<number>} managedRulesId Array of rule IDs to toggle
+ * @param {Array<RuleId>} managedRulesId Array of rule IDs to toggle
  * @param {boolean} newValue Whether to enable or disable rules
  */
 function toggleRules(managedRulesId, newValue) {
@@ -175,7 +175,7 @@ function setVdTotalError(vdObj, errorMsg) {
  * @param {string} idPrefix Scenario ID prefix
  * @param {string} vdName The name of the virtual device
  * @param {string} vdTitle The title of the virtual device
- * @param {Array<number>} managedRulesId Array of rule IDs to toggle on switch
+ * @param {Array<RuleId>} managedRulesId Array of rule IDs to toggle on switch
  * @returns {Object|null} The virtual device object if created, otherwise null
  */
 function createBasicVd(idPrefix, vdName, vdTitle, managedRulesId) {
@@ -211,6 +211,7 @@ function createBasicVd(idPrefix, vdName, vdTitle, managedRulesId) {
     psWBSC['VdList'][vdName] = true;
   }
 
+  /** @type {ControlOptions} */
   var controlCfg = {
     title: {
       en: 'Activate scenario rule',

--- a/src/wbsc-scenario-base.mod.js
+++ b/src/wbsc-scenario-base.mod.js
@@ -67,7 +67,7 @@ function ScenarioBase() {
 
   /**
    * Collection of rule IDs for management
-   * @type {Array<number>}
+   * @type {Array<RuleId>}
    * @private
    */
   this._rules = [];
@@ -280,7 +280,7 @@ ScenarioBase.prototype._continueInitAfterControlsReady = function () {
 /**
  * Convenience wrapper to collect rule IDs created inside subclasses.
  *
- * @param {number} id - ID from defineRule
+ * @param {RuleId} id - ID from defineRule
  */
 ScenarioBase.prototype.addRule = function (id) {
   this._rules.push(id);

--- a/src/wbsc-wait-controls.mod.js
+++ b/src/wbsc-wait-controls.mod.js
@@ -62,10 +62,12 @@ function isControlHealthy(controlPath) {
  * Wait for controls to become ready
  *
  * @param {string[]} controls - Array of control paths, e.g. ["wb-gpio/Relay_1", "wb-gpio/Relay_2"]
- * @param {Object} [options] - Configuration options
+ * @param {Object|Function} options - Configuration options, or the callback
+ *                                itself when options are omitted
  * @param {number} [options.timeout=WAIT_DEF.CONTROLS_WAIT_TIMEOUT_MS] - Max waiting time in milliseconds
  * @param {number} [options.period=WAIT_DEF.CONTROLS_WAIT_PERIOD_MS] - Polling period in milliseconds
- * @param {Function} callback - Callback called upon success or timeout
+ * @param {Function} [callback] - Callback called upon success or timeout
+ *                                (required unless passed as the options argument)
  *                                Signature: callback(err, param1, param2, ...)
  *                                where err is null on success or ControlsTimeoutError on failure
  * @param {...any} [params] - Additional parameters passed to the callback


### PR DESCRIPTION
## What

wb-rules now runs a background TypeScript check (`checkJs`, advisory) over `.js` rule and module files. Running the same check (tsgo 7.1, `--strict false --allowJs --checkJs`, each file alone with `wb-rules.d.ts`) over this repo gave 231 diagnostics in 22 files. This PR fixes what is actually wrong without touching runtime behavior:

**Real bugs (commit 1, `fix:`)** - two implicit globals that only work because modules run in sloppy mode:
- `scenarios/light-control/light-control.mod.js`: `ok = addAllLinkedDevicesToVd(...)` -> `var ok = ...`
- `src/translit.mod.js`: `id = input...` -> `var id = ...`

Neither name is read anywhere else, so the only behavioral difference is that the globals are no longer leaked.

**JSDoc inaccuracies (commit 2, `docs:`)** - comment-only:
- astronomical-timer, schedule: `addCustomControlsToVirtualDevice` documented `@returns {boolean}` but returns nothing (siblings document no return)
- thermostat: `createErrChangeRule` returns a `RuleId`, not a boolean; `ThermostatConfig` documented `pidSettings.kp/ki/kd` while the code and the schema use `pidSettings.pidCoefficients.{kp,ki,kd}` (now via the existing `PidCoefficients` typedef)
- schedule: `ScheduleConfig` gets `hours/minutes/seconds` (set by `parseScheduleTime()`, read everywhere else)
- light-control: `SensorConfig` gets `actionValue`, `resolvedOnValue`, `resolvedOffValue` (read by the code)
- logger: `{Arguments}` -> `{IArguments}`
- pid-engine: five duplicate `@returns` tags on `getState()` merged into one object-shape `@returns`
- virtual-device-helpers: `addLinkedControlRO` documented a non-existent `cellType` param and missed `vDevName`; rule-id arrays typed `Array<RuleId>` instead of `Array<number>`
- wbsc-wait-controls: `waitControls` documented optional `options` before required `callback`; now `{Object|Function} options` + `[callback]` (both call shapes are supported)
- thermostat, virtual-device-helpers: `/** @type {ControlOptions} */` on the reused `controlCfg` variable so the `'switch'`/`'range'`/... tags are not widened to `string`

Also bumps `debian/changelog` to 1.10.2.

## Deliberately left

- **84 x TS2749** (`'XxxScenario' refers to a value, but is being used as a type`): tsgo 7 dropped support for ES5 constructor functions as classes (see `CHANGES.md` in typescript-go: "@class or @constructor does not make a function into a constructor function"). The only one-doc-line workaround (a same-named `@typedef`) makes tsc 5/6 report `Duplicate identifier` and types the instance as `any`, so it was not applied. The real fix (ES6 `class`) is not an option while wb-rules 2.46.x / Duktape must still load these files.
- **78 x TS2339** on the `scenario-init-*.mod.js` files: the raw config entry is `@param {object} scenarioCfg` and there is no typedef describing the raw JSON shape; left as is.
- **3 x TS2339** `notReadyCtrlList` on `Error` in `wbsc-wait-controls.mod.js`: ES5 expando on an Error instance; no clean annotation without casts.

## Verification

- tsgo diagnostics over every `.js` in `scenarios/`, `src/`, `develop/`: **231 -> 87** (TS2749 84 -> 84, TS2339 119 -> 81, TS2304 6 -> 0, TS1223 5 -> 0, TS2345 4 -> 0, TS2322 4 -> 0, TS2739 3 -> 0, TS2552 2 -> 0, TS2355 2 -> 0, TS8024 1 -> 0, TS1016 1 -> 0). No new diagnostics.
- ESLint (repo `eslint.config.cjs`, eslint 9 + eslint-plugin-prettier installed out of tree): identical message set before and after on the changed files (92 pre-existing `func-names` / `no-unused-vars` findings, 0 `prettier/prettier`); nothing new.
- `node --check` passes on every changed file.
- No `let`/`const`/arrow functions/template literals introduced; the files still parse on Duktape-era syntax.


**Update:** a review follow-up commit types the raw scenario configs as `{Object}` (as the rest of the repo does) and rule ids as `RuleId`; the checker total is now 87 (84 TS2749 + 3 expando-on-Error left as described).

## Verified on the old engine too

Installed these modules + `scenario-init-main.js` on a controller downgraded to **wb-rules 2.46.4 (Duktape 1.0.2)**, with a `lightControl` scenario named in Cyrillic («Тестовый свет» → `wbsc_testovyy_svet`, so `translit()`'s `id` path ran) and `isDebugEnabled: true` (so `initSpecific`'s `ok` path ran): the scenario vdev was created, "base initialization completed", motion on → lamp on, motion off → lamp off after the configured delay; no errors. Same on 2.47 (QuickJS).